### PR TITLE
Fix volume module logging typo

### DIFF
--- a/modules/energy/volume.py
+++ b/modules/energy/volume.py
@@ -22,7 +22,7 @@ def calculate_volume_energy(mesh, global_params):
         V0 = (body.target_volume
               if body.target_volume is not None
               else body.options.get("target_volume", 0))
-        logger.debut(f"Default target_volume is 0!")
+        logger.debug(f"Default target_volume is 0!")
         k = body.options.get("volume_stiffness", global_params.volume_stiffness)
 
         volume_energy += 0.5 * k * (V - V0)**2


### PR DESCRIPTION
## Summary
- fix a typo in `modules/energy/volume.py` where `logger.debut` should be `logger.debug`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68402042cf408332974891a4aff8b105