### PR TITLE
Fix loops in minimizer and volume energy

### DIFF
--- a/modules/energy/volume.py
+++ b/modules/energy/volume.py
@@ -1,6 +1,7 @@
 # modules/volume.py
 
 from geometry.entities import Body
+from typing import Dict
 import numpy as np
 from logging_config import setup_logging
 
@@ -17,12 +18,12 @@ def calculate_volume_energy(mesh, global_params):
     """
     volume_energy = 0.0
 
-    for body in mesh.bodies:
+    for body in mesh.bodies.values():
         V = body.calculate_volume()
         V0 = (body.target_volume
               if body.target_volume is not None
               else body.options.get("target_volume", 0))
-        logger.debut(f"Default target_volume is 0!")
+        logger.debug(f"Default target_volume is 0!")
         k = body.options.get("volume_stiffness", global_params.volume_stiffness)
 
         volume_energy += 0.5 * k * (V - V0)**2

--- a/modules/minimizer.py
+++ b/modules/minimizer.py
@@ -34,8 +34,7 @@ class Minimizer:
         self.global_params = global_params
         self.energy_manager = energy_manager
         self.constraint_manager = constraint_manager
-        self.constraint_modules = constraint_manager
-        self.stepper = BaseStepper
+        self.stepper = stepper
         self.step_size = step_size
         self.tol = tol
         self.n_steps = n_steps
@@ -74,27 +73,14 @@ STEP SIZE:\t {self.step_size}
             idx: np.zeros(3) for idx in self.mesh.vertices
         }
 
-        for mod in self.energy_modules:
-            # E_mod - energy module, g_mod - gradient module
-            # TODO: documentation:
-            # write that in new energy modules compute_energy_and_gradient is
-            #   a mandatory name
-            #E_mod, g_mod = mod.compute_energy_and_gradient(
-            #    self.mesh, self.global_params, self.param_resolver
-            #)
-            #volume_energy_list = []
-            #surface_energy_list = []
+        for module in self.energy_modules:
+            # Each energy module must implement compute_energy_and_gradient
+            E_mod, g_mod = module.compute_energy_and_gradient(
+                self.mesh, self.global_params, self.param_resolver)
 
-            for module in self.energy_modules:
-                E_mod, g_mod = module.compute_energy_and_gradient(
-                    self.mesh, self.global_params, self.param_resolver)
-
-                #if   module.__name__ ==   "modules.energy.volume": volume_energy_list.append(E_mod)
-                #elif module.__name__ == "modules.energy.surface": surface_energy_list.append(E_mod)
-        #print(f"[DEBUG] Surface energy: {surface_energy_list}, Volume energy: {volume_energy_list}")
-                total_energy += E_mod
-                for vidx, gvec in g_mod.items():
-                    grad[vidx] += gvec
+            total_energy += E_mod
+            for vidx, gvec in g_mod.items():
+                grad[vidx] += gvec
 
         #if i == 0:
         V  = self.mesh.compute_total_volume()


### PR DESCRIPTION
## Summary
- handle bodies dictionary correctly in `volume.calculate_volume_energy`
- fix logging typo in `volume`
- use provided stepper in `Minimizer`
- remove nested loop in minimizer energy calculation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683fe0e18aa883329be3cc044abdfa0f