### PR TITLE
Refactor minimizer location and utilities

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,8 @@ import os
 from logging_config import setup_logging
 from geometry.geom_io import load_data, save_geometry, parse_geometry
 from geometry.entities import Mesh
-from modules.minimizer import Minimizer, ParameterResolver
+from runtime.minimizer import Minimizer
+from parameters.resolver import ParameterResolver
 from modules.steppers.gradient_descent import GradientDescent
 from modules.steppers.conjugate_gradient import ConjugateGradient
 from runtime.energy_manager import EnergyModuleManager

--- a/modules/constraints/dummy_module.py
+++ b/modules/constraints/dummy_module.py
@@ -1,4 +1,5 @@
-# modules/edge1.py
+"""Dummy constraint module used for testing."""
+
 
 def compute_energy_and_gradient():
     print("THIS IS A DUMMY MODULE FOR TESTING")

--- a/modules/constraints/fix_vertex_position.py
+++ b/modules/constraints/fix_vertex_position.py
@@ -1,0 +1,3 @@
+"""Placeholder for a constraint that fixes a vertex at a specified position."""
+
+# Implementation will be added in the future.

--- a/modules/mean_curvature.py
+++ b/modules/mean_curvature.py
@@ -1,1 +1,3 @@
-# mean_curvature.py
+"""Stub for a mean curvature energy module."""
+
+# Implementation coming soon.

--- a/parameters/resolver.py
+++ b/parameters/resolver.py
@@ -1,0 +1,21 @@
+"""Utility for resolving per-object parameters.
+
+This small helper checks for object-specific
+parameter overrides and falls back to global
+parameters when none are provided.
+"""
+
+from parameters.global_parameters import GlobalParameters
+
+
+class ParameterResolver:
+    """Resolve parameters with optional per-object overrides."""
+
+    def __init__(self, global_params: GlobalParameters):
+        self.global_params = global_params
+
+    def get(self, obj, name: str):
+        """Return parameter ``name`` for ``obj`` or global default."""
+        if obj is None:
+            return self.global_params.get(name)
+        return obj.options.get(name, self.global_params.get(name))

--- a/runtime/__init__.py
+++ b/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Runtime components for the solver."""

--- a/tests/test_energy_manager.py
+++ b/tests/test_energy_manager.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 import sys
 import os
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from modules.minimizer import Minimizer
+from runtime.minimizer import Minimizer
 from modules.steppers.gradient_descent import GradientDescent
 from geometry.entities import Mesh, Vertex, Edge, Facet, Body
 from parameters.global_parameters import GlobalParameters

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -5,7 +5,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from geometry.entities import Mesh, Vertex, Edge, Facet
 from parameters.global_parameters import GlobalParameters
 from modules.energy.surface import compute_energy_and_gradient, calculate_surface_energy
-from modules.minimizer import ParameterResolver
+from parameters.resolver import ParameterResolver
 
 def test_compute_energy_and_gradient():
     # Create a simple triangular mesh

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -2,7 +2,7 @@ import numpy as np
 from geometry.entities import Mesh, Vertex, Edge, Facet, Body
 from parameters.global_parameters import GlobalParameters
 from modules.energy.volume import compute_energy_and_gradient, calculate_volume_energy
-from modules.minimizer import ParameterResolver
+from parameters.resolver import ParameterResolver
 
 def test_volume_energy_and_gradient():
     # Vertices of a unit tetrahedron


### PR DESCRIPTION
## Summary
- move `minimizer.py` to `runtime` and turn the folder into a package
- extract `ParameterResolver` into `parameters/resolver.py`
- update imports across project and tests
- add placeholder docs for empty modules
- add type hints and docstrings to the minimizer

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686199fe85e883329dfe298d37b0d65c