### PR TITLE
Switch to logging and add quiet mode

### DIFF
--- a/logging_config.py
+++ b/logging_config.py
@@ -12,11 +12,13 @@ logger.error('Error while computing volume constraint.')
 logger.critical('Critical error! Cannot proceed further.')
 '''
 
-def setup_logging(log_file='membrane_solver.log'):
+def setup_logging(log_file='membrane_solver.log', quiet: bool = False):
     logger = logging.getLogger('membrane_solver')
 
     if logger.handlers:
-        # Logger is already configured, no need to add handlers again.
+        if quiet:
+            logger.handlers = [h for h in logger.handlers
+                               if not isinstance(h, logging.StreamHandler)]
         return logger
 
     logger.setLevel(logging.DEBUG)
@@ -31,13 +33,12 @@ def setup_logging(log_file='membrane_solver.log'):
     file_handler.setLevel(logging.DEBUG)
     file_handler.setFormatter(formatter)
 
-    # Console handler
-    console_handler = logging.StreamHandler()
-    console_handler.setLevel(logging.INFO)
-    console_handler.setFormatter(formatter)
-
-    # Adding handlers to the logger
     logger.addHandler(file_handler)
-    logger.addHandler(console_handler)
+
+    if not quiet:
+        console_handler = logging.StreamHandler()
+        console_handler.setLevel(logging.INFO)
+        console_handler.setFormatter(formatter)
+        logger.addHandler(console_handler)
 
     return logger

--- a/modules/constraints/dummy_module.py
+++ b/modules/constraints/dummy_module.py
@@ -1,5 +1,9 @@
 """Dummy constraint module used for testing."""
 
+import logging
+
+logger = logging.getLogger('membrane_solver')
+
 
 def compute_energy_and_gradient():
-    print("THIS IS A DUMMY MODULE FOR TESTING")
+    logger.info("THIS IS A DUMMY MODULE FOR TESTING")

--- a/modules/energy/dummy_module.py
+++ b/modules/energy/dummy_module.py
@@ -1,4 +1,8 @@
 # modules/edge1.py
 
+import logging
+
+logger = logging.getLogger('membrane_solver')
+
 def compute_energy_and_gradient():
-    print("THIS IS A DUMMY MODULE FOR TESTING")
+    logger.info("THIS IS A DUMMY MODULE FOR TESTING")

--- a/runtime/steppers/line_search.py
+++ b/runtime/steppers/line_search.py
@@ -1,6 +1,9 @@
 from typing import Dict, Callable
 import numpy as np
+import logging
 from geometry.entities import Mesh
+
+logger = logging.getLogger('membrane_solver')
 
 
 def backtracking_line_search(
@@ -55,7 +58,7 @@ def backtracking_line_search(
     g_dot_d = sum(np.dot(gradient[vidx], direction[vidx]) for vidx in direction)
 
     if g_dot_d >= 0:
-        print("[DEBUG] Non-descent direction provided; skipping step.")
+        logger.debug("Non-descent direction provided; skipping step.")
         return False, step_size
 
     alpha = step_size
@@ -74,20 +77,20 @@ def backtracking_line_search(
 
         trial_energy = energy_fn()
         if trial_energy <= energy0 + c * alpha * g_dot_d:
-            print(f"[DEBUG] Line search accepted step size {alpha:.3e}")
+            logger.debug(f"Line search accepted step size {alpha:.3e}")
             new_step = min(alpha * gamma, alpha_max)
             return True, new_step
 
         alpha *= beta
 
-    print(
-        f"[DEBUG] Line search failed to satisfy Armijo after {max_iter} iterations. Reverting."
+    logger.debug(
+        f"Line search failed to satisfy Armijo after {max_iter} iterations. Reverting."
     )
     for vidx, vertex in mesh.vertices.items():
         if getattr(vertex, "fixed", False):
             continue
         vertex.position[:] = original_positions[vidx]
 
-    print("[DIAGNOSTIC] Zero-step detected: no trial step reduced energy.")
-    print(f"[DIAGNOSTIC] Current step_size = {step_size:.2e}")
+    logger.info("Zero-step detected: no trial step reduced energy.")
+    logger.info(f"Current step_size = {step_size:.2e}")
     return False, step_size


### PR DESCRIPTION
## Summary
- add `quiet` option for logger setup to control console output
- log debug info instead of printing in simulation driver
- print startup metadata when not running quiet
- guard step output with quiet option
- replace prints with logging in line search and dummy modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68625e1d7534833297160f54c6d31a32