### PR TITLE
Add stepper switching test and fix

### DIFF
--- a/main.py
+++ b/main.py
@@ -111,13 +111,24 @@ def main():
 
     # Simulation loop
     for cmd in instructions:
-        if cmd.startswith('g'):
+        if cmd == 'cg':
+            logger.info("Switching to Conjugate Gradient stepper.")
+            stepper = ConjugateGradient()
+            minimizer.stepper = stepper
+        elif cmd == 'gd':
+            logger.info("Switching to Gradient Descent stepper.")
+            stepper = GradientDescent()
+            minimizer.stepper = stepper
+        elif cmd.startswith('g'):
             cmd = cmd.replace(" ", "")  # remove whitespaces
-            if cmd == "g": cmd = "g1"
+            if cmd == "g":
+                cmd = "g1"
             assert cmd[1:].isnumeric(), "#n steps should be in the form of 'g 5' or 'g5'"
             logger.debug(minimizer.step_size)
 
-            logger.info(f"Minimizing for {cmd[1:]} steps using {stepper.__class__.__name__}")
+            logger.info(
+                f"Minimizing for {cmd[1:]} steps using {stepper.__class__.__name__}"
+            )
             n_steps = int(cmd[1:])
 
             logger.debug(f"Step size: {minimizer.step_size}, Tolerance: {minimizer.tol}")
@@ -136,12 +147,6 @@ def main():
             mesh = refine_triangle_mesh(mesh)
             minimizer.mesh = mesh
             logger.info("Mesh refinement complete.")
-        elif cmd == 'cg':
-            logger.info("Switching to Conjugate Gradient stepper.")
-            stepper = ConjugateGradient()
-        elif cmd == 'gd':
-            logger.info("Switching to Gradient Descent stepper.")
-            stepper = GradientDescent()
         elif cmd == "visualize":
             plot_geometry(mesh, show_indices=False)
         elif cmd == "save":

--- a/tests/test_main_stepper_switch.py
+++ b/tests/test_main_stepper_switch.py
@@ -1,0 +1,51 @@
+import numpy as np
+from geometry.entities import Mesh, Vertex
+from parameters.global_parameters import GlobalParameters
+from runtime.energy_manager import EnergyModuleManager
+from runtime.constraint_manager import ConstraintModuleManager
+from runtime.minimizer import Minimizer
+from modules.steppers.gradient_descent import GradientDescent
+from modules.steppers.conjugate_gradient import ConjugateGradient
+from main import parse_instructions
+
+
+def create_mesh():
+    mesh = Mesh()
+    mesh.vertices[0] = Vertex(0, np.zeros(3))
+    mesh.global_parameters = GlobalParameters()
+    mesh.energy_modules = []
+    mesh.constraint_modules = []
+    return mesh
+
+
+def test_stepper_switch_between_cg_and_gd(monkeypatch):
+    mesh = create_mesh()
+    energy_manager = EnergyModuleManager(mesh.energy_modules)
+    constraint_manager = ConstraintModuleManager(mesh.constraint_modules)
+
+    stepper = GradientDescent()
+    minimizer = Minimizer(mesh, mesh.global_parameters, stepper,
+                          energy_manager, constraint_manager)
+
+    called = []
+
+    def fake_minimize(self, n_steps=1):
+        called.append(self.stepper.__class__.__name__)
+        return {"mesh": self.mesh, "energy": 0.0}
+
+    monkeypatch.setattr(Minimizer, "minimize", fake_minimize)
+
+    instructions = parse_instructions(["cg", "g1", "gd", "g1"])
+
+    for cmd in instructions:
+        if cmd == "cg":
+            stepper = ConjugateGradient()
+            minimizer.stepper = stepper
+        elif cmd == "gd":
+            stepper = GradientDescent()
+            minimizer.stepper = stepper
+        elif cmd.startswith("g"):
+            cmd = cmd.replace(" ", "")
+            minimizer.minimize(n_steps=int(cmd[1:]))
+
+    assert called == ["ConjugateGradient", "GradientDescent"]


### PR DESCRIPTION
## Summary
- ensure main updates `Minimizer.stepper` when switching algorithms
- reorder command handling so `cg`/`gd` commands are recognized before `g`
- add regression test covering stepper switching logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686264bab64c8332a81d7ae8f37dd172