### PR TITLE
Implement line search in conjugate gradient

### DIFF
--- a/modules/steppers/conjugate_gradient.py
+++ b/modules/steppers/conjugate_gradient.py
@@ -1,23 +1,55 @@
 # modules/steppers/conjugate_gradient.py
+from __future__ import annotations
+
 import numpy as np
+from typing import Callable, Dict
+
+from geometry.entities import Mesh
+from runtime.steppers.line_search import backtracking_line_search
 from .base import BaseStepper
 
 class ConjugateGradient(BaseStepper):
-    def __init__(self, restart_interval=10, precondition=False):
-        self.prev_grad = {}
-        self.prev_dir = {}
+    """Conjugate gradient stepper with Armijo backtracking line search."""
+
+    def __init__(
+        self,
+        restart_interval: int = 10,
+        precondition: bool = False,
+        max_iter: int = 10,
+        beta: float = 0.5,
+        c: float = 1e-4,
+        gamma: float = 1.2,
+        alpha_max_factor: float = 10.0,
+    ) -> None:
+        self.prev_grad: Dict[int, np.ndarray] = {}
+        self.prev_dir: Dict[int, np.ndarray] = {}
         self.restart_interval = restart_interval
         self.iter_count = 0
         self.precondition = precondition
+        self.max_iter = max_iter
+        self.beta = beta
+        self.c = c
+        self.gamma = gamma
+        self.alpha_max_factor = alpha_max_factor
 
     def reset(self):
         self.prev_grad.clear()
         self.prev_dir.clear()
         self.iter_count = 0
 
-    def step(self, mesh, grad, step_size, energy_fn=None):
+    def step(
+        self,
+        mesh: Mesh,
+        grad: Dict[int, np.ndarray],
+        step_size: float,
+        energy_fn: Callable[[], float],
+    ) -> tuple[bool, float]:
+        """Take one conjugate gradient step with line search."""
+
+        direction: Dict[int, np.ndarray] = {}
+
         for vidx, vertex in mesh.vertices.items():
-            if getattr(vertex, 'fixed', False):
+            if getattr(vertex, "fixed", False):
                 continue
 
             g = grad[vidx]
@@ -25,32 +57,43 @@ class ConjugateGradient(BaseStepper):
             if self.precondition:
                 g = g / (np.linalg.norm(g) + 1e-8)
 
-            restart = False
-            if vidx not in self.prev_grad:
+            if (
+                vidx not in self.prev_grad
+                or self.iter_count % self.restart_interval == 0
+            ):
                 d = -g
             else:
                 prev_g = self.prev_grad[vidx]
                 prev_d = self.prev_dir[vidx]
-                beta = np.dot(g, g - prev_g) / (np.dot(prev_g, prev_g) + 1e-20)  # Polak-Ribiere
-                if beta < 0 or self.iter_count % self.restart_interval == 0:
-                    d = -g  # restart
-                    restart = True
+                beta_pr = np.dot(g, g - prev_g) / (
+                    np.dot(prev_g, prev_g) + 1e-20
+                )
+                if beta_pr < 0:
+                    d = -g
                 else:
-                    d = -g + beta * prev_d
+                    d = -g + beta_pr * prev_d
 
-            d /= (np.linalg.norm(d) + 1e-12)  # normalize
+            d /= np.linalg.norm(d) + 1e-12
+            direction[vidx] = d
 
-            # Simple line search placeholder — can be replaced
-            alpha = step_size
+        success, new_step = backtracking_line_search(
+            mesh,
+            direction,
+            grad,
+            step_size,
+            energy_fn,
+            max_iter=self.max_iter,
+            beta=self.beta,
+            c=self.c,
+            gamma=self.gamma,
+            alpha_max_factor=self.alpha_max_factor,
+        )
 
-            new_pos = vertex.position + alpha * d
-            if hasattr(vertex, 'constraint'):
-                new_pos = vertex.constraint.project_position(new_pos)
+        if success:
+            for vidx, d in direction.items():
+                self.prev_grad[vidx] = grad[vidx].copy()
+                self.prev_dir[vidx] = d.copy()
+            self.iter_count += 1
 
-            vertex.position = new_pos
-            self.prev_grad[vidx] = g.copy()
-            self.prev_dir[vidx] = d.copy()
-
-        self.iter_count += 1
-        return True, step_size
+        return success, new_step
 

--- a/tests/test_conjugate_gradient.py
+++ b/tests/test_conjugate_gradient.py
@@ -1,0 +1,63 @@
+import numpy as np
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from geometry.entities import Mesh, Vertex
+from modules.steppers.conjugate_gradient import ConjugateGradient
+
+
+def quadratic_energy(v: Vertex) -> float:
+    return 0.5 * np.dot(v.position, v.position)
+
+
+def constant_energy() -> float:
+    return 0.0
+
+
+def test_line_search_success_and_history_update():
+    mesh = Mesh()
+    v = Vertex(0, np.array([1.0, 0.0, 0.0]))
+    mesh.vertices[0] = v
+
+    stepper = ConjugateGradient()
+
+    grad = {0: v.position.copy()}
+
+    success, step_size = stepper.step(mesh, grad, 1.0, lambda: quadratic_energy(v))
+
+    assert success
+    assert step_size > 1.0  # grew by gamma
+    assert np.allclose(v.position, np.zeros(3))
+    assert stepper.iter_count == 1
+    assert np.allclose(stepper.prev_grad[0], grad[0])
+    assert np.allclose(stepper.prev_dir[0], -grad[0] / np.linalg.norm(grad[0]))
+
+
+def test_line_search_failure_preserves_history():
+    mesh = Mesh()
+    v = Vertex(0, np.array([1.0, 0.0, 0.0]))
+    mesh.vertices[0] = v
+
+    stepper = ConjugateGradient()
+
+    grad = {0: v.position.copy()}
+    success, step_size = stepper.step(mesh, grad, 1.0, lambda: quadratic_energy(v))
+    assert success
+
+    # Reset vertex position to attempt another step
+    v.position[:] = [1.0, 0.0, 0.0]
+
+    old_grad = stepper.prev_grad.copy()
+    old_dir = stepper.prev_dir.copy()
+    old_iter = stepper.iter_count
+
+    grad2 = {0: v.position.copy()}
+    success2, step_size2 = stepper.step(mesh, grad2, step_size, constant_energy)
+
+    assert not success2
+    assert step_size2 == step_size
+    assert np.allclose(v.position, [1.0, 0.0, 0.0])
+    assert stepper.prev_grad == old_grad
+    assert stepper.prev_dir == old_dir
+    assert stepper.iter_count == old_iter
+


### PR DESCRIPTION
## Summary
- add backtracking line search integration for `ConjugateGradient`
- pass line-search parameters at initialization like `GradientDescent`
- store history only on successful steps
- add regression tests covering step success and failure cases

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68626b411ba083329c4cd1370513a803