### PR TITLE
Add benchmark using full minimization

### DIFF
--- a/benchmarks/benchmark_surface_energy.py
+++ b/benchmarks/benchmark_surface_energy.py
@@ -1,66 +1,70 @@
 #!/usr/bin/env python3
-"""Compare timing between baseline and optimized surface energy calculations."""
+"""Benchmark full minimization using different surface energy modules.
 
+This script runs ``main.py`` on ``meshes/cube.json`` using both the old and the
+new surface energy implementations. The simulation is executed multiple times for
+each variant and the average run time is reported.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
 import time
-from collections import defaultdict
-from typing import Dict, Tuple
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
-import numpy as np
-
-from geometry.geom_io import load_data, parse_geometry
-from modules.energy import surface
-from parameters.global_parameters import GlobalParameters
-from parameters.resolver import ParameterResolver
+BASE_JSON = Path("meshes/cube.json")
+RUNS = 3
 
 
-def compute_energy_and_gradient_baseline(
-    mesh, global_params: GlobalParameters, param_resolver: ParameterResolver, *, compute_gradient: bool = True
-) -> Tuple[float, Dict[int, np.ndarray]]:
-    """Original loop-based implementation for benchmarking."""
-    E = 0.0
-    grad = defaultdict(lambda: np.zeros(3)) if compute_gradient else None
+def _prepare_input(module: str, tmpdir: Path) -> Path:
+    """Return a temporary cube mesh with ``module`` as the surface energy."""
+    with BASE_JSON.open() as fh:
+        data = json.load(fh)
 
-    for facet in mesh.facets.values():
-        surface_tension = param_resolver.get(facet, "surface_tension")
-        if surface_tension is None:
-            surface_tension = global_params.get("surface_tension")
+    new_faces = []
+    for entry in data["faces"]:
+        if isinstance(entry[-1], dict):
+            opts = dict(entry[-1])
+            edges = entry[:-1]
+        else:
+            opts = {}
+            edges = entry
+        opts["energy"] = [module]
+        new_faces.append([*edges, opts])
+    data["faces"] = new_faces
 
-        area = facet.compute_area(mesh)
-        E += surface_tension * area
-
-        if compute_gradient:
-            area_gradient = facet.compute_area_gradient(mesh)
-            for vertex_index, gradient_vector in area_gradient.items():
-                grad[vertex_index] += surface_tension * gradient_vector
-
-    if compute_gradient:
-        return E, dict(grad)
-    return E, {}
+    path = tmpdir / f"cube_{module}.json"
+    with path.open("w") as fh:
+        json.dump(data, fh)
+    return path
 
 
-def benchmark(func, mesh, global_params, param_resolver, *, iterations: int = 1000) -> float:
-    """Return the time (in seconds) required to run ``func`` ``iterations`` times."""
+def _run_simulation(input_path: Path, output_path: Path) -> float:
+    """Execute ``main.py`` and return the elapsed time."""
     start = time.perf_counter()
-    for _ in range(iterations):
-        func(mesh, global_params, param_resolver)
+    subprocess.run(
+        [sys.executable, "main.py", "-i", str(input_path), "-o", str(output_path), "-q"],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
     return time.perf_counter() - start
 
 
+def benchmark(module: str, runs: int = RUNS) -> float:
+    """Return the average run time for ``module`` over ``runs`` executions."""
+    with TemporaryDirectory() as tmp:
+        tmpdir = Path(tmp)
+        inp = _prepare_input(module, tmpdir)
+        out = tmpdir / "out.json"
+        times = [_run_simulation(inp, out) for _ in range(runs)]
+    return sum(times) / runs
+
+
 if __name__ == "__main__":
-    mesh = parse_geometry(load_data("meshes/cube.json"))
-    global_params = GlobalParameters()
-    resolver = ParameterResolver(global_params)
-
-    iterations = 1000
-
-    baseline_time = benchmark(
-        compute_energy_and_gradient_baseline, mesh, global_params, resolver, iterations=iterations
-    )
-    optimized_time = benchmark(
-        surface.compute_energy_and_gradient, mesh, global_params, resolver, iterations=iterations
-    )
-
-    print(f"Baseline time:  {baseline_time:.4f}s")
-    print(f"Optimized time: {optimized_time:.4f}s")
-    if optimized_time:
-        print(f"Speedup:       {baseline_time/optimized_time:.2f}x")
+    for mod in ("surface_old", "surface"):
+        avg = benchmark(mod)
+        print(f"{mod} average runtime over {RUNS} runs: {avg:.4f}s")


### PR DESCRIPTION
## Summary
- overhaul benchmark script to run full cube minimization through `main.py`
- measure average runtime for both `surface` and `surface_old` energy modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864e0ea6bd083329be3cd73bb3397e3