### PR TITLE
Add KH calibration sweep and tighten parity to splay 0.3

### DIFF
--- a/manual.md
+++ b/manual.md
@@ -345,6 +345,8 @@ Interactive commands:
     `python tools/diagnostics/flat_disk_kh_term_audit.py --refine-level 1 --theta-values 0 6.366e-4 0.004`.
   - KH audit refine sweep:
     `python tools/diagnostics/flat_disk_kh_term_audit.py --refine-levels 1 2 --theta-values 0 6.366e-4`.
+  - KH calibration sweep (optimize parity vs splay scale):
+    `python tools/diagnostics/flat_disk_kh_term_audit.py --calibration-sweep --refine-levels 1 --splay-scales 0.3 0.4 0.5 --output /tmp/kh_calibration_sweep.yaml`.
   - KH audit local rim-band refinement:
     add `--rim-local-refine-steps` and `--rim-local-refine-band-lambda`.
   - Scan controls (`--theta-mode scan`):
@@ -360,7 +362,7 @@ Interactive commands:
   - Splay calibration control (benchmark-local):
     `--splay-modulus-scale-in` scales inner `tilt_splay_modulus_in` when
     `--smoothness-model splay_twist` (for refine-3 parity tuning experiments).
-    In `kh_physical` + `splay_twist`, the benchmark auto-calibrates to `0.5`
+    In `kh_physical` + `splay_twist`, the benchmark auto-calibrates to `0.3`
     when this flag is left at `1.0`; pass an explicit value to override.
   - Inner tilt-mass discretization control:
     `--tilt-mass-mode-in auto|lumped|consistent` (default `auto`).

--- a/tests/fixtures/flat_disk_one_leaflet_kh_physical_disabled_baseline.yaml
+++ b/tests/fixtures/flat_disk_one_leaflet_kh_physical_disabled_baseline.yaml
@@ -10,7 +10,7 @@ meta:
   radius_nm: 7.0
   drive_physical: 2.857142857142857
   optimize_preset: kh_wide
-  splay_modulus_scale_in: 0.5
+  splay_modulus_scale_in: 0.3
   tilt_mass_mode_in: consistent
   theta_mode: optimize
   theta_initial: 0.0
@@ -29,27 +29,27 @@ metrics:
     theta_star: 0.14323594888052385
     total: -0.8999780094660339
   optimize:
-    theta_star_raw: 0.09200000000000007
-    theta_star: 0.09200000000000007
+    theta_star_raw: 0.09600000000000007
+    theta_star: 0.09600000000000007
     optimize_theta_span: 0.24
     hit_step_limit: 0.0
   mesh:
-    theta_star: 0.09200000000000007
-    total_energy: -0.5752029989731495
+    theta_star: 0.09600000000000007
+    total_energy: -0.6079892736169625
     planarity_z_span: 0.0
     outer_tilt_max_free_rows: 0.0
     outer_decay_probe_max_before: 0.0
     outer_decay_probe_max_after: 0.0
     profile:
-      inner_abs_median: 0.0002469714960716966
-      rim_abs_median: 0.09200000000000007
-      outer_abs_median: 1.373384376460917e-08
+      inner_abs_median: 0.0003293251880035851
+      rim_abs_median: 0.09600000000000007
+      outer_abs_median: 2.6862211146591995e-09
     rim_continuity:
       matched_bins: 12.0
-      jump_abs_median: 6.788520486977203e-05
+      jump_abs_median: 3.982417485075439e-05
   parity:
-    theta_factor: 1.5569124878317797
-    energy_factor: 1.5646267684151014
+    theta_factor: 1.4920411341721223
+    energy_factor: 1.4802531039931246
 tolerances:
   theory:
     lambda_value: 1.0e-12

--- a/tests/test_flat_disk_one_leaflet_benchmark_e2e.py
+++ b/tests/test_flat_disk_one_leaflet_benchmark_e2e.py
@@ -265,8 +265,8 @@ def test_flat_disk_kh_consistent_mass_improves_parity_with_kh_wide() -> None:
     assert float(consistent["parity"]["energy_factor"]) < float(
         lumped["parity"]["energy_factor"]
     )
-    assert float(consistent["parity"]["theta_factor"]) <= 1.6
-    assert float(consistent["parity"]["energy_factor"]) <= 1.6
+    assert float(consistent["parity"]["theta_factor"]) <= 1.52
+    assert float(consistent["parity"]["energy_factor"]) <= 1.52
 
 
 @pytest.mark.acceptance
@@ -284,8 +284,8 @@ def test_flat_disk_kh_optimize_profile_and_continuity_e2e() -> None:
 
     assert report["meta"]["theta_mode"] == "optimize"
     assert report["meta"]["optimize_preset_effective"] == "kh_wide"
-    assert float(report["parity"]["theta_factor"]) <= 1.6
-    assert float(report["parity"]["energy_factor"]) <= 1.6
+    assert float(report["parity"]["theta_factor"]) <= 1.52
+    assert float(report["parity"]["energy_factor"]) <= 1.52
 
     profile = report["mesh"]["profile"]
     inner = float(profile["inner_abs_median"])
@@ -338,9 +338,9 @@ def test_flat_disk_reports_splay_modulus_scale_meta() -> None:
         outer_mode="disabled",
         smoothness_model="splay_twist",
         theta_mode="optimize",
-        splay_modulus_scale_in=0.5,
+        splay_modulus_scale_in=0.3,
     )
-    assert float(report["meta"]["splay_modulus_scale_in"]) == pytest.approx(0.5)
+    assert float(report["meta"]["splay_modulus_scale_in"]) == pytest.approx(0.3)
 
 
 @pytest.mark.regression
@@ -354,7 +354,7 @@ def test_flat_disk_kh_default_splay_scale_auto_calibrates() -> None:
         parameterization="kh_physical",
         optimize_preset="kh_wide",
     )
-    assert float(report["meta"]["splay_modulus_scale_in"]) == pytest.approx(0.5)
+    assert float(report["meta"]["splay_modulus_scale_in"]) == pytest.approx(0.3)
 
 
 @pytest.mark.regression

--- a/tools/reproduce_flat_disk_one_leaflet.py
+++ b/tools/reproduce_flat_disk_one_leaflet.py
@@ -630,7 +630,7 @@ def run_flat_disk_one_leaflet_benchmark(
         and str(smoothness_model) == "splay_twist"
         and abs(float(splay_modulus_scale_in) - 1.0) < 1e-15
     ):
-        effective_splay_modulus_scale_in = 0.5
+        effective_splay_modulus_scale_in = 0.3
     mass_mode_raw = str(tilt_mass_mode_in).strip().lower()
     if mass_mode_raw == "auto":
         mass_mode = "consistent" if mode == "kh_physical" else "lumped"


### PR DESCRIPTION
## Summary
- Added a new KH calibration-sweep mode in `tools/diagnostics/flat_disk_kh_term_audit.py` to evaluate optimize-parity across `splay_modulus_scale_in`, mass-mode, and refinement settings.
- Extended KH audit APIs/CLI to accept explicit `splay_modulus_scale_in` in standard audit and refine-sweep modes.
- Added regression coverage for calibration-sweep output shape/finite values.
- Tightened KH benchmark default auto-calibration from `0.5` to `0.3` (KH lane only, `kh_physical + splay_twist` when left at default).
- Updated KH optimize baseline fixture and tightened KH parity gates from `<=1.6` to `<=1.52`.
- Updated manual with calibration-sweep usage and new auto-calibrated value.

## Motivation / Context
- You asked to prioritize better results over performance.
- Sweep evidence showed lower `splay_modulus_scale_in` improves KH parity; the best tested refine-1 candidate was `0.3`.
- Cross-refinement check at `0.3` remained stable/improving (refine-2 parity significantly better than refine-1).

## Design Notes
- Feature contract link/summary:
  - Add data-driven calibration diagnostics and tighten KH acceptance around the selected default.
- Interfaces changed (if any):
  - New function: `run_flat_disk_kh_calibration_sweep(...)`.
  - New CLI mode: `--calibration-sweep` in `tools/diagnostics/flat_disk_kh_term_audit.py`.
  - New CLI args for sweep: `--splay-scales`, `--sweep-tilt-mass-modes`, `--optimize-preset`.
  - Existing audit/refine-sweep now accept `--splay-modulus-scale-in`.
- Invariants enforced:
  - Legacy lane untouched.
  - KH lane remains strict-KH analytic reference.
  - Explicit `--splay-modulus-scale-in` still overrides auto-calibration.

## How to Test
```bash
pytest -q tests/test_flat_disk_kh_term_audit_regression.py
pytest -q tests/test_flat_disk_one_leaflet_benchmark_e2e.py -k "kh_consistent_mass_improves_parity_with_kh_wide or kh_optimize_profile_and_continuity_e2e or kh_optimize_parity_does_not_worsen_with_refinement or kh_default_splay_scale_auto_calibrates"
pytest -q tests/test_reproduce_flat_disk_one_leaflet_acceptance.py
```
- Additional targeted tests or reproduction steps (if applicable)
```bash
python tools/diagnostics/flat_disk_kh_term_audit.py --calibration-sweep --refine-levels 1 --splay-scales 0.3 0.4 0.5 --output /tmp/kh_calibration_sweep.yaml
python tools/reproduce_flat_disk_one_leaflet.py --parameterization kh_physical --outer-mode disabled --smoothness-model splay_twist --theta-mode optimize --optimize-preset kh_wide
```

## Risks & Mitigations
- Risk: calibration is lane-scoped and could be mistaken for global physics behavior.
- Mitigation: default override behavior is explicit and documented; legacy lane remains unchanged.
- Risk: tighter KH thresholds increase sensitivity.
- Mitigation: thresholds are based on reproducible measured margins under canonical settings.

## Performance / Benchmarks (if relevant)
- Accuracy-focused PR; no runtime optimization changes.
- Calibration sweep is diagnostic/offline and not part of runtime flow.

## Assumptions / Open Questions
- Assumes KH benchmark parity should be optimized via lane-scoped calibration while avoiding broad solver/runtime edits.
- Follow-up can add a persisted benchmark artifact for calibration-sweep trend tracking if you want CI gating on this mode.
