### PR TITLE
Fix bending-tilt debug payload cache fallback

### DIFF
--- a/modules/energy/bending_tilt_leaflet.py
+++ b/modules/energy/bending_tilt_leaflet.py
@@ -722,7 +722,12 @@ def _leaflet_triangle_payload(
     if use_cache:
         cached = getattr(mesh, cache_attr, None)
         if cached is not None and cached.get("key") == cache_key:
-            return cached["value"]
+            payload = cached["value"]
+            if isinstance(payload, dict) and "tri_area" not in payload:
+                payload = dict(payload)
+                payload.setdefault("tri_area", None)
+                cached["value"] = payload
+            return payload
 
     k_vecs, vertex_areas_vor, weights_full, tri_rows_full = compute_curvature_data(
         mesh, positions, index_map
@@ -736,6 +741,7 @@ def _leaflet_triangle_payload(
             "weights": weights_full,
             "tri_rows": tri_rows_full,
             "tri_keep": np.zeros(0, dtype=bool),
+            "tri_area": None,
             "g0": None,
             "g1": None,
             "g2": None,
@@ -920,7 +926,7 @@ def _total_energy_leaflet(
     vertex_areas_vor = np.asarray(payload["vertex_areas_vor"], dtype=float)
     weights = np.asarray(payload["weights"], dtype=float)
     tri_rows = np.asarray(payload["tri_rows"], dtype=np.int32)
-    tri_area = payload["tri_area"]
+    tri_area = payload.get("tri_area")
     if tri_rows.size == 0:
         return 0.0
 
@@ -1084,7 +1090,7 @@ def compute_energy_and_gradient_array_leaflet(
     weights = np.asarray(payload["weights"], dtype=float)
     tri_rows = np.asarray(payload["tri_rows"], dtype=np.int32)
     tri_keep = np.asarray(payload["tri_keep"], dtype=bool)
-    tri_area = payload["tri_area"]
+    tri_area = payload.get("tri_area")
 
     if tri_rows_full.size == 0 or tri_rows.size == 0:
         return 0.0


### PR DESCRIPTION
## Summary
- make bending-tilt leaflet payload caching tolerate missing `tri_area` in debug diagnostic paths
- backfill cached payload dicts lazily without breaking sentinel-style cache tests
- keep the fix scoped to the bending-tilt payload contract only

## Motivation / Context
- `pytest -q -x` was failing in `tests/test_debug_diagnostics_pure.py` because the debug minimizer copy path called into `bending_tilt_leaflet` with a cached payload that did not contain `tri_area`.
- The failure blocked repo-green status but was unrelated to the flat-KH benchmark work.

## Design Notes
- Feature contract link/summary:
  - No public API changes.
  - This PR hardens the internal payload contract used by the bending-tilt energy module.
- Interfaces changed (if any):
  - None.
- Invariants enforced:
  - Empty/cached leaflet payloads always behave as if `tri_area` were optional.
  - Existing sentinel cache reuse tests keep working.

## How to Test
```bash
pytest -q tests/test_debug_diagnostics_pure.py tests/test_bending_tilt_leaflet_triangle_payload_cache_unit.py
pytest -q
```

## Risks & Mitigations
- Risk: changing cache-return behavior could interfere with cache regression tests.
  - Mitigation: the backfill only applies when the cached value is a real payload dict; non-dict sentinels are returned untouched.
- Risk: `tri_area` fallback could mask a deeper geometry bug.
  - Mitigation: this PR only restores the prior optional-field behavior; it does not change any geometry computation path.

## Performance / Benchmarks (if relevant)
- Full repo suite on a clean branch from `main`:
  - `819 passed, 5 skipped, 171 deselected in 471.84s`

## Assumptions / Open Questions
- This PR intentionally does not include any of the pre-existing dirty Stage A / curved-case worktree changes from the other checkout.
