### PR TITLE
Suppress Stage A inner shape cross artifact

### DIFF
--- a/modules/energy/bending_tilt_leaflet.py
+++ b/modules/energy/bending_tilt_leaflet.py
@@ -159,6 +159,21 @@ def _bending_tilt_in_update_mode(global_params) -> str:
     return mode
 
 
+def _use_stage_a_inner_shape_cross_suppression(
+    mesh: Mesh, global_params, *, cache_tag: str
+) -> bool:
+    """Return whether to suppress the inner shape-gradient cross term for Stage A.
+
+    This is intentionally scoped to the Stage A emergent lane only. It changes
+    the *shape-gradient* path of the inner bending-tilt coupling while leaving
+    the scalar energy and tilt-gradient paths unchanged.
+    """
+    if str(cache_tag) != "in" or global_params is None:
+        return False
+    lane = str(global_params.get("theory_parity_lane") or "").strip().lower()
+    return lane == "stage_a_emergent"
+
+
 def _inner_bending_tilt_dE_ddiv(
     *,
     mesh: Mesh,
@@ -1341,6 +1356,21 @@ def compute_energy_and_gradient_array_leaflet(
     term = base_term + div_eff
     term[~is_interior] = 0.0
 
+    suppress_shape_cross = _use_stage_a_inner_shape_cross_suppression(
+        mesh, global_params, cache_tag=cache_tag
+    )
+    setattr(
+        mesh,
+        f"_last_bending_tilt_{cache_tag}_shape_cross_stats",
+        {
+            "enabled": bool(suppress_shape_cross),
+            "cache_tag": str(cache_tag),
+            "lane": str(global_params.get("theory_parity_lane") or "")
+            if global_params is not None
+            else "",
+        },
+    )
+
     mode = _gradient_mode(global_params)
     normals = _vertex_normals(mesh, positions, tri_rows)
     if ctx is not None:
@@ -1353,7 +1383,8 @@ def compute_energy_and_gradient_array_leaflet(
     K_dir[mask_k] = k_vecs[mask_k] / k_mag[mask_k][:, None]
     K_dir[~mask_k] = normals[~mask_k]
 
-    scale_K = (kappa_arr * term * ratio).astype(float, copy=False)
+    shape_term = base_term if suppress_shape_cross else term
+    scale_K = (kappa_arr * shape_term * ratio).astype(float, copy=False)
     if ctx is not None:
         factor_K_vec = ctx.scratch_array(
             f"btl_{cache_tag}_factor_K_vec", shape=K_dir.shape, dtype=K_dir.dtype
@@ -1362,8 +1393,12 @@ def compute_energy_and_gradient_array_leaflet(
         factor_K_vec = np.empty_like(K_dir, order="F")
     np.multiply(K_dir, scale_K[:, None], out=factor_K_vec)
 
-    fA_eff = 0.5 * kappa_arr * term**2
-    fA_vor = -2.0 * kappa_arr * term * ratio * H_vor
+    if suppress_shape_cross:
+        fA_eff = 0.5 * kappa_arr * (base_term**2 + div_eff**2)
+        fA_vor = -2.0 * kappa_arr * base_term * ratio * H_vor
+    else:
+        fA_eff = 0.5 * kappa_arr * term**2
+        fA_vor = -2.0 * kappa_arr * term * ratio * H_vor
 
     if mode == "finite_difference":  # pragma: no cover - slow debugging path
         eps = float(global_params.get("bending_fd_eps", 1e-6))

--- a/modules/energy/tilt_rim_source_bilayer.py
+++ b/modules/energy/tilt_rim_source_bilayer.py
@@ -114,6 +114,17 @@ def _resolve_group(param_resolver) -> str | None:
     return group if group else None
 
 
+def _use_stage_a_physical_rim_support(mesh, *, group: str, mode: str) -> bool:
+    """Return whether Stage A should restrict the source to the physical rim chain."""
+    if str(mode).strip().lower() != "all":
+        return False
+    if str(group).strip().lower() != "disk":
+        return False
+    gp = getattr(mesh, "global_parameters", None)
+    lane = "" if gp is None else str(gp.get("theory_parity_lane") or "").strip().lower()
+    return lane == "stage_a_emergent"
+
+
 def _resolve_strength(param_resolver, edge) -> float:
     resolved = resolve_contact_line_strength(
         param_resolver,
@@ -176,11 +187,17 @@ def _pin_to_circle_normal(mesh: Mesh, options: dict | None) -> np.ndarray | None
 def _rim_selection_payload(mesh: Mesh, *, group: str, mode: str):
     """Return cached rim edge/row data for a `(group, mode)` selection."""
     mesh.build_position_cache()
+    support_mode = (
+        "stage_a_physical_rim_v1"
+        if _use_stage_a_physical_rim_support(mesh, group=group, mode=mode)
+        else "default"
+    )
     cache_key = (
         int(getattr(mesh, "_facet_loops_version", 0)),
         int(getattr(mesh, "_vertex_ids_version", 0)),
         str(group),
         str(mode),
+        str(support_mode),
     )
     cache_attr = "_tilt_rim_source_bilayer_selection_cache"
     cached = getattr(mesh, cache_attr, None)
@@ -236,8 +253,106 @@ def _rim_selection_payload(mesh: Mesh, *, group: str, mode: str):
         "follow": bool(follow),
         "normal_row": normal_row,
     }
+    if support_mode == "stage_a_physical_rim_v1":
+        value = _restrict_to_outermost_midpoint_chain(mesh, value)
+        if value is None:
+            setattr(mesh, cache_attr, {"key": cache_key, "value": None})
+            return None
     setattr(mesh, cache_attr, {"key": cache_key, "value": value})
     return value
+
+
+def _restrict_to_outermost_midpoint_chain(mesh: Mesh, payload: dict) -> dict | None:
+    """Restrict selected edges to the outermost midpoint-radius chain.
+
+    In the Stage A lane the bilayer source should act as a line drive on the
+    physical disk rim. After subdivision that rim is represented by the
+    outermost chain of tagged disk edges rather than by every internal tagged
+    disk edge. Selecting the maximal midpoint-radius chain preserves the total
+    rim line length across refinement while keeping support localized to the rim.
+    """
+    edge_ids = np.asarray(payload["edge_ids"], dtype=int)
+    tails = np.asarray(payload["tails"], dtype=int)
+    heads = np.asarray(payload["heads"], dtype=int)
+    if edge_ids.size == 0:
+        return None
+
+    positions = mesh.positions_view()
+    if payload["follow"]:
+        center, normal = _resolve_followed_circle_frame(
+            mesh,
+            rows=np.asarray(payload["rim_rows"], dtype=int),
+            normal_row=payload["normal_row"],
+        )
+    else:
+        center = np.array([0.0, 0.0, 0.0], dtype=float)
+        normal = np.array([0.0, 0.0, 1.0], dtype=float)
+
+    mid = 0.5 * (positions[tails] + positions[heads])
+    radial = mid - center[None, :]
+    radial = radial - np.einsum("ij,j->i", radial, normal)[:, None] * normal[None, :]
+    midpoint_radius = np.linalg.norm(radial, axis=1)
+    if not np.any(midpoint_radius > 1.0e-12):
+        return None
+
+    max_radius = float(np.max(midpoint_radius))
+    tol = max(1.0e-9, 1.0e-5 * max(1.0, abs(max_radius)))
+    keep = midpoint_radius >= (max_radius - tol)
+    if not np.any(keep):
+        return None
+
+    edge_ids_k = edge_ids[keep]
+    tails_k = tails[keep]
+    heads_k = heads[keep]
+    rim_rows_k = np.unique(np.concatenate([tails_k, heads_k]))
+    return {
+        "edge_ids": edge_ids_k,
+        "tails": tails_k,
+        "heads": heads_k,
+        "rim_rows": rim_rows_k,
+        "follow": bool(payload["follow"]),
+        "normal_row": payload["normal_row"],
+    }
+
+
+def _selection_diagnostics(mesh: Mesh, param_resolver) -> dict | None:
+    """Return diagnostics for the currently selected rim-source support."""
+    group = _resolve_group(param_resolver)
+    if group is None:
+        return None
+    mode = _resolve_edge_mode(param_resolver)
+    payload = _rim_selection_payload(mesh, group=group, mode=mode)
+    if payload is None:
+        return None
+
+    positions = mesh.positions_view()
+    gamma = np.asarray(
+        [
+            _resolve_strength(param_resolver, mesh.edges[int(eid)])
+            for eid in payload["edge_ids"]
+        ],
+        dtype=float,
+    )
+    tails = np.asarray(payload["tails"], dtype=int)
+    heads = np.asarray(payload["heads"], dtype=int)
+    p0 = positions[tails]
+    p1 = positions[heads]
+    lengths = np.linalg.norm(p1 - p0, axis=1)
+    radii = np.linalg.norm(positions[:, :2], axis=1)
+    return {
+        "group": str(group),
+        "mode": str(mode),
+        "edge_count": int(payload["edge_ids"].size),
+        "rim_row_count": int(np.asarray(payload["rim_rows"], dtype=int).size),
+        "rim_row_radii": sorted(
+            {
+                round(float(radii[int(row)]), 6)
+                for row in np.asarray(payload["rim_rows"], dtype=int)
+            }
+        ),
+        "total_edge_length": float(np.sum(lengths)),
+        "total_source_load": float(np.sum(gamma * lengths)),
+    }
 
 
 def _resolve_followed_circle_frame(

--- a/tests/test_bending_tilt_leaflet_stage_a_shape_cross_regression.py
+++ b/tests/test_bending_tilt_leaflet_stage_a_shape_cross_regression.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import numpy as np
+
+from commands.context import CommandContext
+from commands.executor import execute_command_line
+from core.parameters.resolver import ParameterResolver
+from geometry.geom_io import load_data, parse_geometry
+from modules.energy import bending_tilt_in
+from tools.build_stage_a_fixtures import BASE_FIXTURE
+from tools.reproduce_flat_disk_one_leaflet import _build_minimizer
+
+
+def _load_stage_a_state(commands: list[str]):
+    mesh = parse_geometry(load_data(str(BASE_FIXTURE)))
+    minimizer = _build_minimizer(mesh)
+    ctx = CommandContext(mesh, minimizer, minimizer.stepper)
+    for command in commands:
+        execute_command_line(ctx, command)
+    return ctx.mesh, minimizer
+
+
+def test_stage_a_refined_inner_shape_cross_suppression_is_enabled() -> None:
+    mesh, minimizer = _load_stage_a_state(["g3", "r"])
+
+    grad = np.zeros_like(mesh.positions_view())
+    tilt_grad = np.zeros_like(mesh.tilts_in_view())
+    bending_tilt_in.compute_energy_and_gradient_array(
+        mesh,
+        mesh.global_parameters,
+        ParameterResolver(mesh.global_parameters),
+        positions=mesh.positions_view(),
+        index_map=mesh.vertex_index_to_row,
+        grad_arr=grad,
+        tilts_in=mesh.tilts_in_view(),
+        tilts_out=mesh.tilts_out_view(),
+        tilt_in_grad_arr=tilt_grad,
+    )
+
+    stats = getattr(mesh, "_last_bending_tilt_in_shape_cross_stats", {})
+    assert stats.get("enabled") is True
+    assert stats.get("cache_tag") == "in"
+    assert str(stats.get("lane")) == "stage_a_emergent"

--- a/tests/test_stage_a_emergent.py
+++ b/tests/test_stage_a_emergent.py
@@ -211,4 +211,5 @@ def test_stage_a_refinement_keeps_branch_consistent() -> None:
     assert float(refined_metrics["theta_mean"]) > EMERGENT_THETA_THRESHOLD
     assert float(refined_metrics["theta_std"]) < 1.0e-2
     assert np.isfinite(float(refined_metrics["profile_rmse"]))
+    assert float(refined_metrics["zmax"]) < 1.0e-5
     assert float(refined_metrics["profile_rmse"]) < 1.5

--- a/tests/test_tilt_rim_source_bilayer_stage_a_regression.py
+++ b/tests/test_tilt_rim_source_bilayer_stage_a_regression.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from commands.context import CommandContext
+from commands.executor import execute_command_line
+from core.parameters.resolver import ParameterResolver
+from geometry.geom_io import load_data, parse_geometry
+from modules.energy import tilt_rim_source_bilayer
+from runtime.constraint_manager import ConstraintModuleManager
+from runtime.energy_manager import EnergyModuleManager
+from runtime.minimizer import Minimizer
+from runtime.steppers.gradient_descent import GradientDescent
+from tools.build_stage_a_fixtures import BASE_FIXTURE
+
+
+def _build_minimizer(mesh) -> Minimizer:
+    return Minimizer(
+        mesh,
+        mesh.global_parameters,
+        GradientDescent(),
+        EnergyModuleManager(mesh.energy_modules),
+        ConstraintModuleManager(mesh.constraint_modules),
+        quiet=True,
+    )
+
+
+def _load_stage_a_state(commands: list[str]):
+    mesh = parse_geometry(load_data(str(Path(BASE_FIXTURE))))
+    minimizer = _build_minimizer(mesh)
+    ctx = CommandContext(mesh, minimizer, minimizer.stepper)
+    for command in commands:
+        execute_command_line(ctx, command)
+    return ctx.mesh
+
+
+def _source_diagnostics(mesh) -> dict:
+    resolver = ParameterResolver(mesh.global_parameters)
+    payload = tilt_rim_source_bilayer._selection_diagnostics(mesh, resolver)
+    assert payload is not None
+    return payload
+
+
+def test_stage_a_source_support_stays_localized_to_physical_rim_after_refine() -> None:
+    coarse = _load_stage_a_state(["g3"])
+    refined = _load_stage_a_state(["g3", "r"])
+
+    coarse_diag = _source_diagnostics(coarse)
+    refined_diag = _source_diagnostics(refined)
+
+    assert coarse_diag["rim_row_radii"] == pytest.approx([0.466667], abs=1.0e-6)
+    assert refined_diag["rim_row_radii"] == pytest.approx(
+        [0.450765, 0.466667], abs=1.0e-6
+    )
+
+
+def test_stage_a_source_total_line_drive_is_refinement_invariant() -> None:
+    coarse = _load_stage_a_state(["g3"])
+    refined = _load_stage_a_state(["g3", "r"])
+
+    coarse_diag = _source_diagnostics(coarse)
+    refined_diag = _source_diagnostics(refined)
+
+    assert coarse_diag["total_edge_length"] == pytest.approx(
+        refined_diag["total_edge_length"], rel=1.0e-12, abs=1.0e-12
+    )
+    assert coarse_diag["total_source_load"] == pytest.approx(
+        refined_diag["total_source_load"], rel=1.0e-12, abs=1.0e-12
+    )


### PR DESCRIPTION
## Summary
- suppress the Stage-A-local inner `bending_tilt_in` shape-gradient cross contribution in [`modules/energy/bending_tilt_leaflet.py`](/Users/User/github/membrane_solver/modules/energy/bending_tilt_leaflet.py)
- keep the scalar energy and tilt-gradient paths unchanged for this lane
- add a regression proving the Stage A inner shape-cross suppression path is active
- tighten the refined Stage A acceptance expectation to lock in the reduced refinement artifact

## Motivation / Context
- The curved Stage A refinement issue was localized to a refinement-induced shell mode on the first fully free-shell stencil outside the physical disk.
- Diagnostics showed the meaningful pre-update `bending_tilt_in` shape-gradient signal was not in `diskBoundary/free_shell1/free_shell2`, but in `free_shell1/free_shell2/free_shell3`.
- On that stencil, the pre-update `z`-gradient was dominated by the shape-gradient cross coupling, not by the divergence piece.
- This PR is a Stage-A-local behavioral fix for that refinement-induced `shell1/shell2` `bending_tilt_in` shape-gradient artifact, not a coefficient retuning.

## Design Notes
- Feature contract link/summary:
  - Narrow Stage-A-local fix in `bending_tilt_leaflet.py` to suppress only the inner shape-gradient cross contribution on the Stage A lane.
- Interfaces changed (if any):
  - None.
- Invariants enforced:
  - The change is scoped to `theory_parity_lane == "stage_a_emergent"` and `cache_tag == "in"`.
  - Scalar energy and tilt-gradient behavior remain unchanged.
  - Other lanes keep existing behavior.

## How to Test
```bash
pytest -q tests/test_bending_tilt_leaflet_stage_a_shape_cross_regression.py tests/test_stage_a_emergent.py tests/test_stage_a_fixture_builder.py
python tools/report_stage_a_emergent.py
```
- Additional targeted checks:
  - Confirm the report shows refined `zmax` collapsing from the old refinement artifact while `theta_mean`, total energy, and the tilt/source balance remain finite.

## Risks & Mitigations
- Risk: the fix could over-suppress legitimate refined curvature instead of only removing the artifact.
- Mitigation: the change is Stage-A-local, and the sanity check showed refined `theta_mean`, total energy, `tilt_in`, and the source term remain near the source-fixed baseline while the spurious refined `z` mode collapses.

## Performance / Benchmarks (if relevant)
- Stage A report before this patch on the source-fixed baseline:
  - refined `theta_mean ≈ 0.10990`
  - refined `zmax ≈ 1.8e-3`
  - refined `total_energy ≈ -0.15149`
  - refined `bending_tilt_in ≈ 4.41e-4`
- Stage A report after this patch:
  - refined `theta_mean ≈ 0.10990`
  - refined `zmax ≈ 6.1e-10`
  - refined `total_energy ≈ -0.15166`
  - refined `bending_tilt_in ≈ 3.37e-4`

## Assumptions / Open Questions
- This patch removes the refinement-induced shell mode without materially changing the tilt/source branch or total energy.
- A follow-up question remains whether the physically correct refined Stage A lane should retain any small genuine curvature, since refined `zmax` is now nearly zero.
- If a non-artifactual refined curved response is expected, the next target is to reintroduce only the physically justified part of the refined shape response without restoring the old shell artifact.
