### PR TITLE
Document Stage A level-1 reference schedule

### DIFF
--- a/docs/TILT_BENCHMARKS.md
+++ b/docs/TILT_BENCHMARKS.md
@@ -278,6 +278,14 @@ Use a **nontrivial surface with J≈0** to confirm that the reduction
 **Expected**
 - Surface approaches a catenoid-like minimal surface: `J ≈ 0` away from boundaries.
 
+**Current Stage A benchmark reference**
+- For the current stabilized Stage A lane, use the level-1 refinement path
+  `g3 -> r -> g5` as the benchmark reference schedule.
+- This is a benchmark-definition choice, not a statement that deeper schedules
+  are converged or physically preferred.
+- Schedule exploration beyond `g5` (`g10`, `g20`, `cg`, mixed paths) should be
+  treated as a separate study, not folded into the benchmark reference.
+
 ### Stage B (add rim tilt source)
 - Impose a tilt source on one boundary ring (Dirichlet or anchoring band).
 - Solve for tilt on the (nearly) minimal surface (geometry fixed or weakly coupled).

--- a/tests/test_stage_a_report.py
+++ b/tests/test_stage_a_report.py
@@ -9,6 +9,9 @@ def test_stage_a_report_contains_all_cases_and_flat_reference() -> None:
     assert set(report["cases"]) == {"base", "seeded", "continuation", "refined"}
     assert float(report["flat_reference"]["theta_star"]) > 0.0
     assert float(report["flat_reference"]["total_energy"]) < 0.0
+    assert report["meta"]["reference_schedules"]["level1"] == ["g3", "r", "g5"]
+    assert "benchmark reference" in report["meta"]["level1_reference_schedule_note"]
+    assert report["cases"]["refined"]["commands"] == ["g3", "r", "g5"]
 
     for metrics in report["cases"].values():
         assert metrics["branch"] in {"emergent_curved", "flat_control"}

--- a/tools/report_stage_a_emergent.py
+++ b/tools/report_stage_a_emergent.py
@@ -38,6 +38,10 @@ DEFAULT_OUT = (
 TARGET_EMERGENT_THETA = 0.18
 EMERGENT_Z_THRESHOLD = 5.0e-5
 EMERGENT_THETA_THRESHOLD = 1.0e-2
+STAGE_A_REFERENCE_SCHEDULES = {
+    "level0": ["g3"],
+    "level1": ["g3", "r", "g5"],
+}
 
 
 def _load_mesh_from_fixture(path: Path):
@@ -204,6 +208,12 @@ def build_stage_a_report(
             "target_emergent_theta": TARGET_EMERGENT_THETA,
             "emergent_theta_threshold": EMERGENT_THETA_THRESHOLD,
             "emergent_z_threshold": EMERGENT_Z_THRESHOLD,
+            "reference_schedules": STAGE_A_REFERENCE_SCHEDULES,
+            "level1_reference_schedule_note": (
+                "Use g3 -> r -> g5 as the current Stage A level-1 benchmark "
+                "reference. Deeper schedules are a separate branch-exploration "
+                "question, not part of the benchmark definition."
+            ),
         },
         "flat_reference": {
             "theta_star": float(theory.theta_star),
@@ -213,7 +223,9 @@ def build_stage_a_report(
             "base": _run_fixture(base_fixture, ["g5"]),
             "seeded": _run_fixture(seeded_fixture, ["g5"]),
             "continuation": _run_continuation(base_fixture),
-            "refined": _run_fixture(base_fixture, ["g3", "r", "g3"]),
+            "refined": _run_fixture(
+                base_fixture, STAGE_A_REFERENCE_SCHEDULES["level1"]
+            ),
         },
     }
     return report


### PR DESCRIPTION
## Summary
- record the current Stage A level-1 benchmark reference schedule as `g3 -> r -> g5`
- update the Stage A report metadata so the reference schedule is explicit in generated diagnostics
- make the Stage A report use the documented level-1 reference schedule for its `refined` case
- add a regression that locks the report metadata and command list to the documented schedule

## Motivation / Context
- the current stabilized Stage A lane has a practical level-1 benchmark reference schedule, but it was not documented or encoded explicitly in the reporting path
- this PR keeps the benchmark definition separate from deeper schedule exploration, which remains a different technical question

## Design Notes
- Feature contract link/summary:
  - small docs/reporting change only; no solver or physics changes
- Interfaces changed (if any):
  - none
- Invariants enforced:
  - the Stage A report explicitly records the benchmark reference schedule
  - the level-1 benchmark reference remains `g3 -> r -> g5`
  - deeper schedules are not folded into the benchmark definition in this PR

## How to Test
```bash
pytest -q tests/test_stage_a_report.py tests/test_stage_a_emergent.py tests/test_stage_a_fixture_builder.py
python tools/report_stage_a_emergent.py
```
- confirm the generated report includes the reference schedule metadata and the `refined` case command list `['g3', 'r', 'g5']`

## Risks & Mitigations
- risk is limited to benchmark/report metadata drift
- the regression test locks both the metadata and the `refined` case commands to reduce accidental schedule changes

## Performance / Benchmarks (if relevant)
- N/A

## Assumptions / Open Questions
- this PR intentionally does not address the residual level-2 artifact
- this PR intentionally does not compare deeper relaxation schedules; that remains a separate future study
