### PR TITLE
Document Stage A post-merge operator redesign status

### DIFF
--- a/docs/TILT_BENCHMARKS.md
+++ b/docs/TILT_BENCHMARKS.md
@@ -286,6 +286,23 @@ Use a **nontrivial surface with J≈0** to confirm that the reduction
 - Schedule exploration beyond `g5` (`g10`, `g20`, `cg`, mixed paths) should be
   treated as a separate study, not folded into the benchmark reference.
 
+**Current Stage A redesign status**
+- PR #496 is merged as the first operator-focused redesign pass.
+- That pass changes only the outer `grad_linear` transition coupling; scalar
+  energy, tilt gradient, `grad_cot`, and `grad_area` remain on the previous
+  formulation.
+- On the level-2 audit, it materially reduces the dominant shell seed from
+  about `+0.05498 / -0.00604 / +0.14762` to
+  `+0.02504 / -0.01826 / +0.11321`.
+- On the first `g1` after the second refine, the oscillation is reduced
+  overall: the first and outer shell lobes shrink in magnitude, even though the
+  middle shell remains present.
+- Stage A levels `0` and `1` remain unchanged to reporting precision, and the
+  targeted flat KH lane remains green.
+- This is a qualified improvement, not a full collapse of the residual level-2
+  shell-scale pattern, so further operator-focused follow-up may still be
+  needed.
+
 ### Stage B (add rim tilt source)
 - Impose a tilt source on one boundary ring (Dirichlet or anchoring band).
 - Solve for tilt on the (nearly) minimal surface (geometry fixed or weakly coupled).


### PR DESCRIPTION
## Summary
- record the post-merge Stage A status after PR #496 in the benchmark/status note
- state that PR #496 is the first operator-focused redesign pass
- state that it materially reduces but does not fully eliminate the residual level-2 shell-scale artifact

## Motivation / Context
- `main` should carry an explicit status checkpoint after the first operator-focused redesign pass
- this keeps the current Stage A state documented before any future level-2 follow-up stream

## Design Notes
- Feature contract link/summary:
  - docs/status update only
- Interfaces changed (if any):
  - none
- Invariants enforced:
  - no solver or model behavior changes
  - no benchmark definition changes beyond documenting current merged status

## How to Test
```bash
pytest -q tests/test_bending_tilt_leaflet_stage_a_outer_grad_linear_transition_regression.py tests/test_stage_a_emergent.py tests/test_stage_a_fixture_builder.py
python tools/report_stage_a_emergent.py
pytest -q tests/test_flat_disk_one_leaflet_theory_unit.py tests/test_flat_disk_kh_outer_vertex_audit_regression.py tests/test_flat_disk_kh_term_audit_regression.py tests/test_flat_disk_one_leaflet_benchmark_e2e.py -k 'kh_physical or benchmark_reference or reference_values or reports_finite_rows or screening_resolution'
```

## Risks & Mitigations
- risk: the status note could drift from current merged behavior
- mitigation: the note was updated only after rerunning the same targeted validation used for PR #496 on current `main`

## Performance / Benchmarks (if relevant)
- not a performance PR
- validated current merged status against the Stage A level-2 seed, first-step oscillation, Stage A levels `0/1/2`, and flat KH targeted regressions

## Assumptions / Open Questions
- next future work, if any, should remain operator-focused and begin with diagnostics on the remaining transition-region discretization beyond `grad_linear`
- no new prototype or redesign implementation is started in this PR
