### PR TITLE
Prototype Stage A outer grad_linear transition patch operator

### DIFF
--- a/modules/energy/bending_tilt_leaflet.py
+++ b/modules/energy/bending_tilt_leaflet.py
@@ -199,7 +199,7 @@ def _outer_transition_operator_payload(
     tri_rows_full: np.ndarray,
     tri_rows: np.ndarray,
 ) -> dict[str, np.ndarray]:
-    """Build cached edge-local transition payload for the outer grad_linear operator."""
+    """Build cached transition-patch payload for the outer grad_linear operator."""
     cache_attr = "_bending_tilt_out_transition_operator_payload"
     cache_key = (
         int(mesh._facet_loops_version),
@@ -278,17 +278,122 @@ def _outer_transition_operator_payload(
     )
     same_mask = ~transition_mask
 
+    transition_full_vertex_mask = np.zeros(n_vertices, dtype=bool)
+    transition_full_a = transition_mask & (edge_domain_a == 2)
+    transition_full_b = transition_mask & (edge_domain_b == 2)
+    if np.any(transition_full_a):
+        transition_full_vertex_mask[np.unique(edge_endpoint_a[transition_full_a])] = (
+            True
+        )
+    if np.any(transition_full_b):
+        transition_full_vertex_mask[np.unique(edge_endpoint_b[transition_full_b])] = (
+            True
+        )
+    partial_vertex_mask = domain == 1
+    halo_full_vertex_mask = transition_full_vertex_mask & (domain == 2)
+    patch_vertex_mask = partial_vertex_mask | halo_full_vertex_mask
+
+    edge_unique_idx = np.empty((n_tri, 3), dtype=np.int32)
+    unique_edge_u: list[int] = []
+    unique_edge_v: list[int] = []
+    edge_to_unique: dict[tuple[int, int], int] = {}
+    for tri_idx in range(n_tri):
+        for edge_idx in range(3):
+            a = int(edge_endpoint_a[tri_idx, edge_idx])
+            b = int(edge_endpoint_b[tri_idx, edge_idx])
+            key = (a, b) if a < b else (b, a)
+            unique_idx = edge_to_unique.get(key)
+            if unique_idx is None:
+                unique_idx = len(unique_edge_u)
+                edge_to_unique[key] = unique_idx
+                unique_edge_u.append(key[0])
+                unique_edge_v.append(key[1])
+            edge_unique_idx[tri_idx, edge_idx] = unique_idx
+
+    unique_edge_u_arr = np.asarray(unique_edge_u, dtype=np.int32)
+    unique_edge_v_arr = np.asarray(unique_edge_v, dtype=np.int32)
+    patch_internal_edge_mask = (
+        patch_vertex_mask[unique_edge_u_arr] & patch_vertex_mask[unique_edge_v_arr]
+    )
+    patch_boundary_edge_mask = (
+        patch_vertex_mask[unique_edge_u_arr] ^ patch_vertex_mask[unique_edge_v_arr]
+    )
+    exterior_edge_mask = ~(patch_internal_edge_mask | patch_boundary_edge_mask)
+
+    adjacency: dict[int, list[int]] = {
+        int(row): [] for row in np.flatnonzero(patch_vertex_mask)
+    }
+    for edge_idx, is_internal in enumerate(patch_internal_edge_mask):
+        if not is_internal:
+            continue
+        u = int(unique_edge_u_arr[edge_idx])
+        v = int(unique_edge_v_arr[edge_idx])
+        adjacency[u].append(v)
+        adjacency[v].append(u)
+
+    patch_component_rows: list[np.ndarray] = []
+    patch_boundary_rows: list[np.ndarray] = []
+    seen = np.zeros(n_vertices, dtype=bool)
+    for start in np.flatnonzero(patch_vertex_mask):
+        if seen[start]:
+            continue
+        stack = [int(start)]
+        component: list[int] = []
+        seen[start] = True
+        while stack:
+            row = stack.pop()
+            component.append(row)
+            for neighbor in adjacency.get(row, ()):
+                if not seen[neighbor]:
+                    seen[neighbor] = True
+                    stack.append(neighbor)
+        component_rows = np.asarray(sorted(component), dtype=np.int32)
+        patch_component_rows.append(component_rows)
+
+        component_mask = np.zeros(n_vertices, dtype=bool)
+        component_mask[component_rows] = True
+        boundary_edge_mask = (
+            component_mask[unique_edge_u_arr] ^ component_mask[unique_edge_v_arr]
+        )
+        boundary_rows = np.unique(
+            np.concatenate(
+                (
+                    unique_edge_u_arr[
+                        boundary_edge_mask & ~component_mask[unique_edge_u_arr]
+                    ],
+                    unique_edge_v_arr[
+                        boundary_edge_mask & ~component_mask[unique_edge_v_arr]
+                    ],
+                )
+            )
+        )
+        patch_boundary_rows.append(boundary_rows.astype(np.int32, copy=False))
+
     value = {
         "domain": domain,
         "participation": participation,
         "edge_endpoint_a": edge_endpoint_a,
         "edge_endpoint_b": edge_endpoint_b,
+        "edge_domain_a": edge_domain_a,
+        "edge_domain_b": edge_domain_b,
+        "edge_unique_idx": edge_unique_idx,
+        "unique_edge_u": unique_edge_u_arr,
+        "unique_edge_v": unique_edge_v_arr,
         "recon_a_idx": recon_a_idx,
         "recon_b_idx": recon_b_idx,
         "recon_a_count": recon_a_count,
         "recon_b_count": recon_b_count,
         "transition_mask": transition_mask,
         "same_mask": same_mask,
+        "partial_vertex_mask": partial_vertex_mask,
+        "halo_full_vertex_mask": halo_full_vertex_mask,
+        "transition_full_vertex_mask": transition_full_vertex_mask,
+        "patch_vertex_mask": patch_vertex_mask,
+        "patch_internal_edge_mask": patch_internal_edge_mask,
+        "patch_boundary_edge_mask": patch_boundary_edge_mask,
+        "exterior_edge_mask": exterior_edge_mask,
+        "patch_component_rows": patch_component_rows,
+        "patch_boundary_rows": patch_boundary_rows,
     }
     setattr(mesh, cache_attr, {"key": cache_key, "value": value})
     return value
@@ -313,7 +418,7 @@ def _mean_reconstructed_field(
     return out
 
 
-def _apply_transition_aware_beltrami_laplacian(
+def _apply_edge_reconstructed_beltrami_laplacian(
     mesh: Mesh,
     *,
     positions: np.ndarray,
@@ -322,17 +427,13 @@ def _apply_transition_aware_beltrami_laplacian(
     tri_rows_full: np.ndarray,
     field: np.ndarray,
     cache_tag: str,
+    payload: dict[str, np.ndarray] | None = None,
 ) -> tuple[np.ndarray, dict[str, object]]:
-    """Apply a transition-aware outer grad_linear operator.
-
-    The reconstructed state is the vector field ``factor_K_vec`` itself. On
-    same-domain edges, the operator reduces to the current cotan/Beltrami form.
-    On partial<->full transition edges, the field jump uses reconstructed
-    same-domain side states instead of the raw endpoint states.
-    """
-    payload = _outer_transition_operator_payload(
-        mesh, tri_rows_full=tri_rows_full, tri_rows=tri_rows
-    )
+    """Apply the merged PR #496 transition-edge reconstruction operator."""
+    if payload is None:
+        payload = _outer_transition_operator_payload(
+            mesh, tri_rows_full=tri_rows_full, tri_rows=tri_rows
+        )
     edge_endpoint_a = np.asarray(payload["edge_endpoint_a"], dtype=np.int32)
     edge_endpoint_b = np.asarray(payload["edge_endpoint_b"], dtype=np.int32)
     recon_a_idx = np.asarray(payload["recon_a_idx"], dtype=np.int32)
@@ -431,6 +532,227 @@ def _apply_transition_aware_beltrami_laplacian(
         "reconstructed_state_variable": "factor_K_vec",
         "reconstruction_rule": "same-domain edge-adjacent third-vertex averaging",
         "transition_example": example,
+        "shell_summary": shell_summary,
+    }
+    return out, stats
+
+
+def _apply_transition_aware_beltrami_laplacian(
+    mesh: Mesh,
+    *,
+    positions: np.ndarray,
+    weights: np.ndarray,
+    tri_rows: np.ndarray,
+    tri_rows_full: np.ndarray,
+    field: np.ndarray,
+    cache_tag: str,
+) -> tuple[np.ndarray, dict[str, object]]:
+    """Apply a patch-local outer grad_linear operator on the transition region."""
+    payload = _outer_transition_operator_payload(
+        mesh, tri_rows_full=tri_rows_full, tri_rows=tri_rows
+    )
+    patch_vertex_mask = np.asarray(payload["patch_vertex_mask"], dtype=bool)
+    if not np.any(patch_vertex_mask):
+        return _apply_edge_reconstructed_beltrami_laplacian(
+            mesh,
+            positions=positions,
+            weights=weights,
+            tri_rows=tri_rows,
+            tri_rows_full=tri_rows_full,
+            field=field,
+            cache_tag=cache_tag,
+            payload=payload,
+        )
+
+    edge_endpoint_a = np.asarray(payload["edge_endpoint_a"], dtype=np.int32)
+    edge_endpoint_b = np.asarray(payload["edge_endpoint_b"], dtype=np.int32)
+    edge_unique_idx = np.asarray(payload["edge_unique_idx"], dtype=np.int32)
+    unique_edge_u = np.asarray(payload["unique_edge_u"], dtype=np.int32)
+    unique_edge_v = np.asarray(payload["unique_edge_v"], dtype=np.int32)
+    transition_mask = np.asarray(payload["transition_mask"], dtype=bool)
+    participation = np.asarray(payload["participation"], dtype=float)
+    partial_vertex_mask = np.asarray(payload["partial_vertex_mask"], dtype=bool)
+    halo_full_vertex_mask = np.asarray(payload["halo_full_vertex_mask"], dtype=bool)
+    transition_full_vertex_mask = np.asarray(
+        payload["transition_full_vertex_mask"], dtype=bool
+    )
+    patch_internal_edge_mask = np.asarray(
+        payload["patch_internal_edge_mask"], dtype=bool
+    )
+    patch_boundary_edge_mask = np.asarray(
+        payload["patch_boundary_edge_mask"], dtype=bool
+    )
+    exterior_edge_mask = np.asarray(payload["exterior_edge_mask"], dtype=bool)
+    patch_component_rows = payload["patch_component_rows"]
+    patch_boundary_rows = payload["patch_boundary_rows"]
+
+    coeff_scalar = 0.5 * np.asarray(weights, dtype=float)
+    coeff_unique = np.bincount(
+        edge_unique_idx.ravel(),
+        weights=coeff_scalar.ravel(),
+        minlength=int(len(unique_edge_u)),
+    )
+
+    effective_field = field.copy()
+    fallback_component_count = 0
+    fallback_vertex_mask = np.zeros(len(mesh.vertex_ids), dtype=bool)
+    fallback = _apply_edge_reconstructed_beltrami_laplacian(
+        mesh,
+        positions=positions,
+        weights=weights,
+        tri_rows=tri_rows,
+        tri_rows_full=tri_rows_full,
+        field=field,
+        cache_tag=cache_tag,
+        payload=payload,
+    )
+    fallback_out = fallback[0]
+
+    for component_index, rows in enumerate(patch_component_rows):
+        rows = np.asarray(rows, dtype=np.int32)
+        if rows.size == 0:
+            continue
+        boundary_rows = np.asarray(patch_boundary_rows[component_index], dtype=np.int32)
+        if boundary_rows.size == 0:
+            fallback_component_count += 1
+            fallback_vertex_mask[rows] = True
+            continue
+
+        local_index = {int(row): idx for idx, row in enumerate(rows)}
+        size = int(rows.size)
+        lhs = np.zeros((size, size), dtype=float)
+        rhs = np.zeros((size, 3), dtype=float)
+        component_mask = np.zeros(len(mesh.vertex_ids), dtype=bool)
+        component_mask[rows] = True
+
+        touching_edges = np.where(
+            component_mask[unique_edge_u] | component_mask[unique_edge_v]
+        )[0]
+        for edge_idx in touching_edges:
+            weight = float(coeff_unique[edge_idx])
+            if weight == 0.0:
+                continue
+            u = int(unique_edge_u[edge_idx])
+            v = int(unique_edge_v[edge_idx])
+            iu = local_index.get(u, -1)
+            iv = local_index.get(v, -1)
+            if iu >= 0 and iv >= 0:
+                lhs[iu, iu] += weight
+                lhs[iv, iv] += weight
+                lhs[iu, iv] -= weight
+                lhs[iv, iu] -= weight
+            elif iu >= 0:
+                lhs[iu, iu] += weight
+                rhs[iu] += weight * field[v]
+            elif iv >= 0:
+                lhs[iv, iv] += weight
+                rhs[iv] += weight * field[u]
+
+        try:
+            solved = np.linalg.solve(lhs, rhs)
+        except np.linalg.LinAlgError:
+            fallback_component_count += 1
+            fallback_vertex_mask[rows] = True
+            if boundary_rows.size:
+                fallback_vertex_mask[boundary_rows] = True
+            continue
+        effective_field[rows] = solved
+
+    out = _apply_beltrami_laplacian(weights, tri_rows, effective_field)
+    if np.any(fallback_vertex_mask):
+        out[fallback_vertex_mask] = fallback_out[fallback_vertex_mask]
+
+    eff_a = effective_field[edge_endpoint_a]
+    eff_b = effective_field[edge_endpoint_b]
+    coeff = coeff_scalar[:, :, None]
+    flux = coeff * (eff_a - eff_b)
+    occ_internal_mask = patch_internal_edge_mask[edge_unique_idx]
+    occ_boundary_mask = patch_boundary_edge_mask[edge_unique_idx]
+    occ_exterior_mask = exterior_edge_mask[edge_unique_idx]
+
+    patch_internal_flux = np.where(occ_internal_mask[..., None], flux, 0.0)
+    patch_boundary_flux = np.where(occ_boundary_mask[..., None], flux, 0.0)
+    exterior_flux = np.where(occ_exterior_mask[..., None], flux, 0.0)
+
+    out_patch_internal = np.zeros_like(field)
+    out_patch_boundary = np.zeros_like(field)
+    out_exterior = np.zeros_like(field)
+    for edge_idx in range(3):
+        a = edge_endpoint_a[:, edge_idx]
+        b = edge_endpoint_b[:, edge_idx]
+        fi = patch_internal_flux[:, edge_idx, :]
+        fb = patch_boundary_flux[:, edge_idx, :]
+        fe = exterior_flux[:, edge_idx, :]
+        np.add.at(out_patch_internal, a, fi)
+        np.add.at(out_patch_internal, b, -fi)
+        np.add.at(out_patch_boundary, a, fb)
+        np.add.at(out_patch_boundary, b, -fb)
+        np.add.at(out_exterior, a, fe)
+        np.add.at(out_exterior, b, -fe)
+
+    radii = np.linalg.norm(positions[:, :2], axis=1)
+    patch_shell_summary: list[dict[str, float | int]] = []
+    for radius in np.unique(np.round(radii[patch_vertex_mask], 6)):
+        rows = np.where(patch_vertex_mask & np.isclose(radii, radius, atol=1.0e-5))[0]
+        if rows.size == 0:
+            continue
+        patch_shell_summary.append(
+            {
+                "radius": float(np.mean(radii[rows])),
+                "vertex_count": int(rows.size),
+                "participation_mean": float(np.mean(participation[rows])),
+            }
+        )
+
+    shell_summary: list[dict[str, float | int]] = []
+    for target in _OUTER_TRANSITION_OPERATOR_SHELLS:
+        rows = np.where(np.isclose(radii, target, atol=1.0e-5))[0]
+        if rows.size == 0:
+            continue
+        shell_summary.append(
+            {
+                "radius": float(np.mean(radii[rows])),
+                "vertex_count": int(rows.size),
+                "patch_internal_z_mean": float(np.mean(out_patch_internal[rows, 2])),
+                "patch_boundary_z_mean": float(np.mean(out_patch_boundary[rows, 2])),
+                "exterior_z_mean": float(np.mean(out_exterior[rows, 2])),
+                "total_z_mean": float(np.mean(out[rows, 2])),
+            }
+        )
+
+    patch_example = None
+    if patch_component_rows:
+        rows = np.asarray(patch_component_rows[0], dtype=np.int32)
+        boundary_rows = np.asarray(patch_boundary_rows[0], dtype=np.int32)
+        sample_rows = boundary_rows[: min(3, boundary_rows.size)]
+        patch_example = {
+            "component_index": 0,
+            "patch_vertex_count": int(rows.size),
+            "boundary_vertex_count": int(boundary_rows.size),
+            "component_radii": np.unique(np.round(radii[rows], 6)).tolist(),
+            "boundary_factor_K_vec_sample": effective_field[sample_rows].tolist(),
+        }
+
+    stats = {
+        "enabled": True,
+        "mode": "outer_grad_linear_transition_patch_operator_v1",
+        "cache_tag": str(cache_tag),
+        "lane": str(mesh.global_parameters.get("theory_parity_lane") or ""),
+        "transition_edge_count": int(np.sum(transition_mask)),
+        "same_domain_edge_count": int(np.sum(~transition_mask)),
+        "patch_component_count": int(len(patch_component_rows)),
+        "patch_vertex_count": int(np.sum(patch_vertex_mask)),
+        "partial_vertex_count": int(np.sum(partial_vertex_mask)),
+        "halo_full_vertex_count": int(np.sum(halo_full_vertex_mask)),
+        "halo_vertices_are_direct_transition_full_endpoints": bool(
+            np.array_equal(halo_full_vertex_mask, transition_full_vertex_mask)
+        ),
+        "fallback_component_count": int(fallback_component_count),
+        "exterior_uses_raw_state": True,
+        "reconstructed_state_variable": "factor_K_vec",
+        "reconstruction_rule": "patch-local Dirichlet harmonic solve",
+        "patch_example": patch_example,
+        "patch_shell_summary": patch_shell_summary,
         "shell_summary": shell_summary,
     }
     return out, stats

--- a/tests/test_bending_tilt_leaflet_stage_a_outer_grad_linear_transition_regression.py
+++ b/tests/test_bending_tilt_leaflet_stage_a_outer_grad_linear_transition_regression.py
@@ -39,20 +39,40 @@ def test_stage_a_outer_grad_linear_transition_operator_is_enabled() -> None:
 
     stats = getattr(mesh, "_last_bending_tilt_out_grad_linear_transition_stats", {})
     assert stats.get("enabled") is True
-    assert stats.get("mode") == "outer_grad_linear_transition_operator_v1"
+    assert stats.get("mode") == "outer_grad_linear_transition_patch_operator_v1"
     assert stats.get("cache_tag") == "out"
     assert str(stats.get("lane")) == "stage_a_emergent"
     assert stats.get("reconstructed_state_variable") == "factor_K_vec"
-    assert stats.get("nontransition_uses_raw_state") is True
+    assert stats.get("exterior_uses_raw_state") is True
     assert int(stats.get("transition_edge_count", 0)) > 0
-    assert int(stats.get("same_domain_edge_count", 0)) > 0
+    assert int(stats.get("patch_component_count", 0)) > 0
+    assert int(stats.get("patch_vertex_count", 0)) > 0
+    assert int(stats.get("partial_vertex_count", 0)) > 0
+    assert int(stats.get("halo_full_vertex_count", 0)) > 0
+    assert stats.get("halo_vertices_are_direct_transition_full_endpoints") is True
+    assert int(stats.get("fallback_component_count", -1)) == 0
 
-    example = stats.get("transition_example") or {}
-    assert example.get("endpoint_domains") in (["partial", "full"], ["full", "partial"])
-    raw = np.asarray(example.get("raw_endpoint_factor_K_vec"), dtype=float)
-    recon = np.asarray(example.get("reconstructed_side_states"), dtype=float)
-    assert raw.shape == (2, 3)
-    assert recon.shape == (2, 3)
+    example = stats.get("patch_example") or {}
+    assert int(example.get("component_index", -1)) >= 0
+    assert int(example.get("patch_vertex_count", 0)) > 0
+    assert int(example.get("boundary_vertex_count", 0)) > 0
+    field = np.asarray(example.get("boundary_factor_K_vec_sample"), dtype=float)
+    assert field.ndim == 2
+    assert field.shape[1] == 3
+
+    patch_shell_summary = {
+        round(float(item["radius"]), 6): item
+        for item in stats.get("patch_shell_summary", [])
+    }
+    assert set(patch_shell_summary) == {
+        0.837822,
+        0.842474,
+        0.853008,
+        0.866643,
+        0.965910,
+        0.974541,
+        0.999984,
+    }
 
     shell_summary = {
         round(float(item["radius"]), 6): item for item in stats.get("shell_summary", [])
@@ -60,6 +80,7 @@ def test_stage_a_outer_grad_linear_transition_operator_is_enabled() -> None:
     for radius in (0.965910, 0.974541, 0.999984):
         item = shell_summary[radius]
         assert int(item["vertex_count"]) > 0
-        assert np.isfinite(float(item["transition_z_mean"]))
-        assert np.isfinite(float(item["same_z_mean"]))
+        assert np.isfinite(float(item["patch_internal_z_mean"]))
+        assert np.isfinite(float(item["patch_boundary_z_mean"]))
+        assert np.isfinite(float(item["exterior_z_mean"]))
         assert np.isfinite(float(item["total_z_mean"]))


### PR DESCRIPTION
## Summary
- replace the PR #496 edge-local outer `grad_linear` transition reconstruction with a patch-local solve on the coupled partial-support + first full-support halo region
- keep scalar energy, tilt gradient, `grad_cot`, `grad_area`, support weighting, and public interfaces unchanged
- add focused regression coverage for patch membership, first-halo invariants, and patch diagnostics
- collapse the residual level-2 target-shell pre-update seed and first-`g1` oscillation to numerical zero on the known Stage A mesh

## Motivation / Context
- PR #496 established that the remaining Stage A level-2 artifact was still operator-side and still dominated by outer `grad_linear`
- later diagnostics showed the residual pattern was confined to the coupled transition region, and edge-local transition or halo treatments were not enough
- this PR tests the next operator step: solve `grad_linear` on the whole transition patch at once instead of reconstructing edge states one edge at a time

## Design Notes
- Feature contract link/summary:
  - first patch-local outer `grad_linear` redesign pass
  - only the outer `grad_linear` operator is changed, and only inside the coupled transition patch
  - outside the patch, the operator reduces to the current merged behavior
- Interfaces changed (if any):
  - none
- Invariants enforced:
  - scalar energy, tilt gradient, `grad_cot`, and `grad_area` are unchanged
  - support weighting is unchanged
  - no new public knobs or config are introduced
  - the patch is exactly `partial + first full-support halo`, with no deeper interior expansion

## How to Test
```bash
pytest -q tests/test_bending_tilt_leaflet_stage_a_outer_grad_linear_transition_regression.py tests/test_stage_a_emergent.py tests/test_stage_a_fixture_builder.py
pytest -q tests/test_flat_disk_one_leaflet_theory_unit.py tests/test_flat_disk_kh_outer_vertex_audit_regression.py tests/test_flat_disk_kh_term_audit_regression.py tests/test_flat_disk_one_leaflet_benchmark_e2e.py -k 'kh_physical or benchmark_reference or reference_values or reports_finite_rows or screening_resolution'
```
- Additional targeted diagnostics used for this prototype:
  - pre-update level-2 seed at `r ≈ 0.965910 / 0.974541 / 0.999984`
  - first `g1` after second refine on those same shells
  - final relaxed Stage A summaries for level `0`, level `1`, and level `2`

## Risks & Mitigations
- The main risk is that a patch-local solve could distort lower-refinement behavior or overfit the known transition region.
- This PR reduces that risk by:
  - limiting the change to outer `grad_linear` only
  - keeping the cotan/transmissibility coefficients unchanged
  - keeping a focused regression on patch membership and diagnostics
  - verifying Stage A levels `0/1` remain stable and flat KH stays green

## Performance / Benchmarks (if relevant)
- This touches a hot path numerically, so the benchmark is the actual affected Stage A solve path rather than a synthetic microbenchmark.
- Before (current merged main after PR #496), pre-update level-2 seed on the target shells:
  - `+0.02504 / -0.01826 / +0.11321`
- After this prototype:
  - `~+2.9e-14 / -2.9e-14 / +2.7e-14`
- Before, first `g1` target-shell `z`:
  - `-2.16e-5 / +1.61e-5 / -9.53e-5`
- After this prototype:
  - effectively numerical zero on all three target shells

## Assumptions / Open Questions
- This is the first patch-local outer `grad_linear` redesign. It replaces the PR #496 edge-local transition reconstruction only inside the coupled transition patch.
- Scalar energy, tilt gradient, `grad_cot`, `grad_area`, support weighting, and public interfaces remain unchanged.
- The prototype clears the current Stage A gate, but review should still decide whether follow-up operator work is needed outside `grad_linear` after this lands.
