### PR TITLE
Add curved 1-disk diagnostic benchmarks

### DIFF
--- a/tests/test_curved_1disk_forced_theta_diagnostic.py
+++ b/tests/test_curved_1disk_forced_theta_diagnostic.py
@@ -1,0 +1,52 @@
+import pytest
+
+from tools.diagnostics.curved_1disk_forced_theta_diagnostic import (
+    run_curved_1disk_forced_theta_diagnostic,
+)
+
+
+@pytest.mark.benchmark
+@pytest.mark.slow
+def test_curved_1disk_forced_theta_diagnostic_runs_and_reports_required_sections() -> (
+    None
+):
+    """Benchmark diagnostic: forced-theta curved report emits the required sections."""
+    report = run_curved_1disk_forced_theta_diagnostic()
+
+    assert report["forced_theta_values"] == [0.06, 0.12, 0.1845693593]
+    assert report["theory"]["R"] == pytest.approx(7.0 / 15.0)
+    assert report["theory"]["lambda_theory"] == pytest.approx(15.0)
+
+    assert len(report["cases"]) == 3
+    for case, theta in zip(report["cases"], report["forced_theta_values"]):
+        assert case["theta_B"] == pytest.approx(theta, abs=1.0e-12)
+        assert case["phi_star_forced"] == pytest.approx(0.5 * theta, abs=1.0e-12)
+        assert case["outer_k1"]["shell_count"] > 0
+        assert case["outer_height_log"]["shell_count"] > 0
+        assert case["outer_slope"]["shell_count"] > 0
+        assert case["outer_curvature"]["shell_count"] > 0
+        assert case["outer_leaflet_mismatch"]["shell_count"] > 0
+        assert "outer_elastic_numeric" in case["outer_elastic"]
+        assert "outer_elastic_over_theta_B_sq" in case["outer_elastic"]
+        assert case["axisymmetry"]["judgment"] in {
+            "axisymmetric enough",
+            "noticeable azimuthal scatter",
+        }
+
+    assert report["outer_elastic_scaling"]["classification"] in {
+        "approximately quadratic",
+        "subquadratic",
+        "superquadratic",
+    }
+    diagnosis = report["diagnosis"]
+    assert diagnosis["dominant_failure"] in {
+        "outer shape response",
+        "outer tilt response",
+        "coupling",
+    }
+    assert diagnosis["branch_preference_interpretation"] in {
+        "the realized coupled energy genuinely favors a different branch",
+        "the geometry solver/path is too stiff or constrained",
+    }
+    assert isinstance(diagnosis["recommended_next_stream"], str)
+    assert diagnosis["recommended_next_stream"]

--- a/tests/test_curved_1disk_theory_benchmark.py
+++ b/tests/test_curved_1disk_theory_benchmark.py
@@ -1,0 +1,79 @@
+import pytest
+
+from tools.diagnostics.curved_1disk_theory_benchmark import (
+    run_curved_1disk_theory_benchmark,
+)
+
+
+@pytest.mark.benchmark
+@pytest.mark.slow
+def test_curved_1disk_theory_benchmark_reports_current_tensionless_miss() -> None:
+    """Benchmark diagnostic: current main does not yet lock the curved TeX target."""
+    report = run_curved_1disk_theory_benchmark()
+
+    assert report["canonical_schedule"] == {
+        "theta_scans": 4,
+        "theta_offsets": [-0.02, 0.0, 0.01, 0.02, 0.04, 0.06, 0.08, 0.1, 0.12, 0.14],
+        "shape_steps": 60,
+        "refine_steps": 1,
+    }
+
+    theory = report["theory"]
+    assert theory["lambda_theory"] == pytest.approx(15.0, abs=1.0e-12)
+    assert theory["theta_B_opt"] == pytest.approx(0.1845693593, abs=1.0e-10)
+    assert theory["phi_star"] == pytest.approx(0.0922846796, abs=1.0e-10)
+    assert theory["F_tot"] == pytest.approx(-1.1597607985, abs=1.0e-10)
+
+    assert report["benchmark_lock_passed"] is False
+    assert set(report["benchmark_lock_failures"]) == {
+        "theta_B_opt",
+        "inner_i1_fit",
+        "outer_k1_fit",
+        "outer_height_log_fit",
+        "total_energy",
+        "inner_elastic",
+        "outer_elastic",
+        "contact_energy",
+    }
+
+    theta_b_num = float(report["theta_B_selected"])
+    assert theta_b_num < 0.5 * float(theory["theta_B_opt"])
+
+    near_rim = report["near_rim"]
+    assert float(near_rim["phi_over_theta_B"]) == pytest.approx(0.5, rel=0.10)
+    assert float(near_rim["theta_in_over_half_theta_B"]) == pytest.approx(1.0, rel=0.15)
+    assert float(near_rim["theta_out_over_half_theta_B"]) == pytest.approx(
+        1.0, rel=0.15
+    )
+
+    fits = report["fits"]
+    inner_fit = fits["inner_i1"]
+    assert float(inner_fit["lambda_fit"]) > 4.0 * float(theory["lambda_theory"])
+    assert float(inner_fit["rel_rmse"]) > 0.05
+    assert inner_fit["window"] == [0.25, 0.75]
+
+    outer_fit = fits["outer_k1"]
+    assert float(outer_fit["lambda_fit"]) == pytest.approx(10.0, rel=0.0, abs=1.0e-9)
+    assert float(outer_fit["rel_rmse"]) > 0.20
+    assert outer_fit["window"] == [2.0, 10.0]
+    assert float(outer_fit["leaflet_mismatch_median"]) > 1.0
+
+    height_fit = fits["outer_height_log"]
+    assert float(height_fit["slope_fit"]) == pytest.approx(0.0, abs=1.0e-12)
+    assert float(height_fit["rel_rmse"]) == pytest.approx(0.0, abs=1.0e-12)
+    assert height_fit["window"] == [3.0, 10.0]
+
+    curvature = report["outer_curvature"]
+    assert float(curvature["mean_abs_J"]) <= 0.05
+    assert float(curvature["p95_abs_J"]) <= 0.15
+
+    energies = report["energies"]
+    assert float(energies["total_numeric"]) > float(theory["F_tot"])
+    assert float(energies["inner_elastic_numeric"]) < 0.01
+    assert float(energies["outer_elastic_numeric"]) > 0.5
+    assert abs(float(energies["contact_numeric"])) < 0.5 * abs(float(theory["F_cont"]))
+
+    outer_sensitivity = report["outer_window_sensitivity"]
+    assert float(outer_sensitivity["lambda_fit_spread"]) <= 0.10
+    assert float(outer_sensitivity["log_slope_spread"]) <= 0.10
+    assert report["last_free_shell_radius"] > 10.0

--- a/tools/diagnostics/curved_1disk_forced_theta_diagnostic.py
+++ b/tools/diagnostics/curved_1disk_forced_theta_diagnostic.py
@@ -1,0 +1,576 @@
+#!/usr/bin/env python3
+"""Forced-theta diagnostic for the curved 1-disk coupled response."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Iterable
+
+import numpy as np
+from scipy.special import k1
+
+from geometry.curvature import compute_curvature_fields
+from tools.diagnostics.curved_1disk_theory_benchmark import (
+    OUTER_K1_WINDOW,
+    OUTER_LOG_WINDOW,
+    _compute_numeric_energy_split,
+    _fit_outer_k1,
+    _fit_outer_log_height,
+    _run_curved_theta_candidate,
+    _shell_profile,
+)
+from tools.diagnostics.curved_disk_theory import (
+    compute_curved_disk_theory,
+    tex_reference_params,
+)
+
+FORCED_THETA_VALUES = (0.06, 0.12, 0.1845693593)
+SCATTER_JUDGMENT_THRESHOLD = 0.10
+
+
+def _positions_radii(mesh) -> np.ndarray:
+    """Return radial distance in the xy plane for every vertex."""
+    return np.linalg.norm(mesh.positions_view()[:, :2], axis=1)
+
+
+def _window_rows(
+    shell_rows: list[dict[str, float]],
+    *,
+    radius: float,
+    window: tuple[float, float],
+    last_free_shell_radius: float,
+) -> list[dict[str, float]]:
+    """Return shell rows inside a benchmark radial window."""
+    r_lo = float(window[0]) * float(radius)
+    r_hi = min(float(window[1]) * float(radius), float(last_free_shell_radius) - 1.0e-6)
+    return [row for row in shell_rows if r_lo <= float(row["radius"]) <= r_hi]
+
+
+def _relative_rmse(y: np.ndarray, yhat: np.ndarray) -> float:
+    """Return RMSE normalized by the max signal magnitude."""
+    scale = max(float(np.max(np.abs(y))), 1.0e-12)
+    return float(np.sqrt(np.mean((y - yhat) ** 2)) / scale)
+
+
+def _shell_vertex_samples(mesh) -> dict[float, dict[str, np.ndarray | float | int]]:
+    """Return per-shell raw vertex samples for scatter diagnostics."""
+    positions = mesh.positions_view()
+    radii = _positions_radii(mesh)
+    tilts_in = mesh.tilts_in_view()
+    tilts_out = mesh.tilts_out_view()
+    r_hat = np.zeros_like(positions)
+    good = radii > 1.0e-12
+    r_hat[good, 0] = positions[good, 0] / radii[good]
+    r_hat[good, 1] = positions[good, 1] / radii[good]
+    theta_in = np.einsum("ij,ij->i", tilts_in, r_hat)
+    theta_out = np.einsum("ij,ij->i", tilts_out, r_hat)
+    theta_shared = 0.5 * (theta_in + theta_out)
+    fields = compute_curvature_fields(mesh, positions, mesh.vertex_index_to_row)
+    mean_curvature = fields.mean_curvature
+
+    samples: dict[float, dict[str, np.ndarray | float | int]] = {}
+    for radius_key in sorted({round(float(r), 6) for r in radii if r > 1.0e-12}):
+        mask = np.isclose(radii, float(radius_key), atol=1.0e-6)
+        if not np.any(mask):
+            continue
+        rr = float(np.median(radii[mask]))
+        samples[rr] = {
+            "radius": rr,
+            "count": int(np.sum(mask)),
+            "theta_in": np.asarray(theta_in[mask], dtype=float),
+            "theta_out": np.asarray(theta_out[mask], dtype=float),
+            "theta_shared": np.asarray(theta_shared[mask], dtype=float),
+            "z": np.asarray(positions[mask, 2], dtype=float),
+            "J": np.asarray(mean_curvature[mask], dtype=float),
+        }
+    return samples
+
+
+def _shell_mad(values: np.ndarray) -> float:
+    """Return the median absolute deviation."""
+    med = float(np.median(values))
+    return float(np.median(np.abs(values - med)))
+
+
+def _scatter_summary(
+    samples: dict[float, dict[str, np.ndarray | float | int]],
+    shell_rows: list[dict[str, float]],
+    *,
+    radius: float,
+    last_free_shell_radius: float,
+) -> dict[str, object]:
+    """Return azimuthal scatter summaries over the outer region."""
+    outer_rows = [
+        row
+        for row in shell_rows
+        if float(row["radius"]) > float(radius) + 1.0e-6
+        and float(row["radius"]) < float(last_free_shell_radius) + 1.0e-6
+    ]
+    per_shell: list[dict[str, float]] = []
+    for row in outer_rows:
+        rr = float(row["radius"])
+        shell = samples[rr]
+        theta_shared = np.asarray(shell["theta_shared"], dtype=float)
+        z_vals = np.asarray(shell["z"], dtype=float)
+        j_vals = np.asarray(shell["J"], dtype=float)
+        theta_med = float(np.median(theta_shared))
+        z_med = float(np.median(z_vals))
+        j_med = float(np.median(j_vals))
+        per_shell.append(
+            {
+                "radius": rr,
+                "count": int(shell["count"]),
+                "theta_shared_median": theta_med,
+                "theta_shared_rel_mad": _shell_mad(theta_shared)
+                / max(abs(theta_med), 1.0e-12),
+                "z_median": z_med,
+                "z_rel_mad": _shell_mad(z_vals) / max(abs(z_med), 1.0e-12),
+                "J_median": j_med,
+                "J_rel_mad": _shell_mad(j_vals) / max(abs(j_med), 1.0e-12),
+            }
+        )
+
+    def _worst_in_window(window: tuple[float, float], field: str) -> float:
+        rows = _window_rows(
+            per_shell,
+            radius=radius,
+            window=window,
+            last_free_shell_radius=last_free_shell_radius,
+        )
+        if not rows:
+            return 0.0
+        return float(max(float(row[field]) for row in rows))
+
+    worst_k1 = _worst_in_window(OUTER_K1_WINDOW, "theta_shared_rel_mad")
+    worst_log = _worst_in_window(OUTER_LOG_WINDOW, "z_rel_mad")
+    judgment = (
+        "axisymmetric enough"
+        if worst_k1 <= SCATTER_JUDGMENT_THRESHOLD
+        and worst_log <= SCATTER_JUDGMENT_THRESHOLD
+        else "noticeable azimuthal scatter"
+    )
+    return {
+        "per_shell": per_shell,
+        "worst_theta_shared_rel_scatter_outer_k1_window": worst_k1,
+        "worst_z_rel_scatter_outer_log_window": worst_log,
+        "judgment": judgment,
+    }
+
+
+def _outer_leaflet_mismatch_summary(
+    shell_rows: list[dict[str, float]],
+    *,
+    radius: float,
+    last_free_shell_radius: float,
+) -> dict[str, object]:
+    """Return distal/proximal mismatch across the outer fit window."""
+    rows = _window_rows(
+        shell_rows,
+        radius=radius,
+        window=OUTER_K1_WINDOW,
+        last_free_shell_radius=last_free_shell_radius,
+    )
+    shell_table: list[dict[str, float]] = []
+    rels: list[float] = []
+    for row in rows:
+        signal = max(abs(float(row["theta_shared"])), 1.0e-12)
+        rel = abs(float(row["theta_in"]) - float(row["theta_out"])) / signal
+        rels.append(rel)
+        shell_table.append(
+            {
+                "radius": float(row["radius"]),
+                "theta_in": float(row["theta_in"]),
+                "theta_out": float(row["theta_out"]),
+                "theta_shared": float(row["theta_shared"]),
+                "relative_mismatch": float(rel),
+            }
+        )
+    rel_arr = np.asarray(rels, dtype=float)
+    return {
+        "shell_count": int(len(rows)),
+        "shell_table": shell_table,
+        "median_relative_mismatch": float(np.median(rel_arr)) if rel_arr.size else 0.0,
+        "max_relative_mismatch": float(np.max(rel_arr)) if rel_arr.size else 0.0,
+    }
+
+
+def _outer_k1_summary(
+    shell_rows: list[dict[str, float]],
+    *,
+    radius: float,
+    lambda_theory: float,
+    theta_b: float,
+    last_free_shell_radius: float,
+) -> dict[str, object]:
+    """Return outer tilt comparison to the theoretical K1 law."""
+    fit = _fit_outer_k1(
+        shell_rows,
+        radius=radius,
+        lambda_theory=lambda_theory,
+        last_free_shell_radius=last_free_shell_radius,
+        window=OUTER_K1_WINDOW,
+    )
+    rows = _window_rows(
+        shell_rows,
+        radius=radius,
+        window=OUTER_K1_WINDOW,
+        last_free_shell_radius=last_free_shell_radius,
+    )
+    theory_denom = float(k1(float(lambda_theory) * float(radius)))
+    shell_table = [
+        {
+            "radius": float(row["radius"]),
+            "theta_in": float(row["theta_in"]),
+            "theta_out": float(row["theta_out"]),
+            "theta_shared": float(row["theta_shared"]),
+            "theta_K1_theory": float(
+                0.5
+                * float(theta_b)
+                * float(k1(float(lambda_theory) * float(row["radius"])))
+                / theory_denom
+            ),
+        }
+        for row in rows
+    ]
+    return {**fit, "shell_count": int(len(rows)), "shell_table": shell_table}
+
+
+def _outer_height_summary(
+    shell_rows: list[dict[str, float]],
+    *,
+    radius: float,
+    theta_b: float,
+    last_free_shell_radius: float,
+) -> dict[str, object]:
+    """Return outer height comparison to the logarithmic theory law."""
+    slope_theory = 0.5 * float(theta_b) * float(radius)
+    fit = _fit_outer_log_height(
+        shell_rows,
+        radius=radius,
+        slope_theory=slope_theory,
+        last_free_shell_radius=last_free_shell_radius,
+        window=OUTER_LOG_WINDOW,
+    )
+    rows = _window_rows(
+        shell_rows,
+        radius=radius,
+        window=OUTER_LOG_WINDOW,
+        last_free_shell_radius=last_free_shell_radius,
+    )
+    z0 = float(fit["z0_fit"])
+    shell_table = []
+    residuals = []
+    for row in rows:
+        rr = float(row["radius"])
+        z_theory = z0 + slope_theory * float(np.log(rr / float(radius)))
+        residual = float(row["z"]) - z_theory
+        residuals.append(residual)
+        shell_table.append(
+            {
+                "radius": rr,
+                "z": float(row["z"]),
+                "z_log_theory": z_theory,
+                "residual": residual,
+            }
+        )
+    res_arr = np.asarray(residuals, dtype=float)
+    return {
+        **fit,
+        "shell_count": int(len(rows)),
+        "theory_slope": slope_theory,
+        "shell_table": shell_table,
+        "max_abs_residual": float(np.max(np.abs(res_arr))) if res_arr.size else 0.0,
+        "median_abs_residual": float(np.median(np.abs(res_arr)))
+        if res_arr.size
+        else 0.0,
+    }
+
+
+def _outer_slope_summary(
+    shell_rows: list[dict[str, float]],
+    *,
+    radius: float,
+    theta_b: float,
+    last_free_shell_radius: float,
+) -> dict[str, object]:
+    """Return slope comparison against phi_* R / r on the outer log window."""
+    rows = _window_rows(
+        shell_rows,
+        radius=radius,
+        window=OUTER_LOG_WINDOW,
+        last_free_shell_radius=last_free_shell_radius,
+    )
+    if len(rows) < 3:
+        return {
+            "window": [float(OUTER_LOG_WINDOW[0]), float(OUTER_LOG_WINDOW[1])],
+            "shell_count": 0,
+            "shell_table": [],
+            "rel_rmse": 0.0,
+            "max_abs_residual": 0.0,
+        }
+    radii = np.asarray([float(row["radius"]) for row in rows], dtype=float)
+    z_vals = np.asarray([float(row["z"]) for row in rows], dtype=float)
+    r_mid = radii[1:-1]
+    phi_num = (z_vals[2:] - z_vals[:-2]) / (radii[2:] - radii[:-2])
+    phi_theory = 0.5 * float(theta_b) * float(radius) / r_mid
+    residuals = phi_num - phi_theory
+    shell_table = [
+        {
+            "radius": float(rr),
+            "phi_numeric": float(pn),
+            "phi_theory": float(pt),
+            "residual": float(res),
+        }
+        for rr, pn, pt, res in zip(r_mid, phi_num, phi_theory, residuals)
+    ]
+    return {
+        "window": [float(OUTER_LOG_WINDOW[0]), float(OUTER_LOG_WINDOW[1])],
+        "shell_count": int(len(shell_table)),
+        "shell_table": shell_table,
+        "rel_rmse": _relative_rmse(phi_num, phi_theory),
+        "max_abs_residual": float(np.max(np.abs(residuals))),
+    }
+
+
+def _outer_curvature_diagnostic(
+    shell_rows: list[dict[str, float]],
+    *,
+    radius: float,
+    last_free_shell_radius: float,
+) -> dict[str, object]:
+    """Return shellwise outer curvature plus summary statistics."""
+    rows = [
+        row
+        for row in shell_rows
+        if float(row["radius"]) > float(radius) + 1.0e-6
+        and float(row["radius"]) < float(last_free_shell_radius) + 1.0e-6
+    ]
+    abs_j = np.asarray([abs(float(row["J"])) for row in rows], dtype=float)
+    return {
+        "shell_count": int(len(rows)),
+        "shell_table": [
+            {"radius": float(row["radius"]), "J": float(row["J"])} for row in rows
+        ],
+        "mean_abs_J": float(np.mean(abs_j)) if abs_j.size else 0.0,
+        "p95_abs_J": float(np.percentile(abs_j, 95.0)) if abs_j.size else 0.0,
+    }
+
+
+def _classify_outer_elastic_scaling(
+    cases: Iterable[dict[str, object]],
+) -> tuple[str, dict[str, float]]:
+    """Classify outer-elastic scaling with theta_B."""
+    rows = sorted(cases, key=lambda row: float(row["theta_B"]))
+    theta_vals = np.asarray([float(row["theta_B"]) for row in rows], dtype=float)
+    normalized = np.asarray(
+        [float(row["outer_elastic"]["outer_elastic_over_theta_B_sq"]) for row in rows],
+        dtype=float,
+    )
+    median_norm = float(np.median(normalized))
+    spread = float(
+        (np.max(normalized) - np.min(normalized)) / max(abs(median_norm), 1.0e-12)
+    )
+    first = float(normalized[0])
+    last = float(normalized[-1])
+    if spread <= 0.15:
+        kind = "approximately quadratic"
+    elif last < first * (1.0 - 0.15):
+        kind = "subquadratic"
+    else:
+        kind = "superquadratic"
+    return kind, {
+        "normalized_spread": spread,
+        "theta_values": [float(v) for v in theta_vals],
+        "normalized_values": [float(v) for v in normalized],
+    }
+
+
+def _diagnose(cases: list[dict[str, object]], *, radius: float) -> dict[str, object]:
+    """Return the final diagnostic call and recommendation."""
+    near_rim_good = all(
+        abs(float(case["near_rim"]["phi_over_theta_B"]) - 0.5) <= 0.05
+        and abs(float(case["near_rim"]["theta_in_over_half_theta_B"]) - 1.0) <= 0.15
+        and abs(float(case["near_rim"]["theta_out_over_half_theta_B"]) - 1.0) <= 0.15
+        for case in cases
+    )
+    outer_tilt_bad = any(
+        float(case["outer_k1"]["rel_rmse"]) > 0.10
+        or float(case["outer_leaflet_mismatch"]["median_relative_mismatch"]) > 0.05
+        for case in cases
+    )
+    outer_shape_bad = any(
+        float(case["outer_height_log"]["slope_fit"]) == pytest_approx_zero_placeholder()
+        or float(case["outer_height_log"]["rel_rmse"]) > 0.20
+        or float(case["outer_slope"]["rel_rmse"]) > 0.20
+        for case in cases
+    )
+    mean_js = [float(case["outer_curvature"]["mean_abs_J"]) for case in cases]
+    curvature_grows = mean_js[-1] > max(1.5 * mean_js[0], mean_js[0] + 0.02)
+
+    if outer_tilt_bad and outer_shape_bad and curvature_grows:
+        dominant = "coupling"
+    elif outer_shape_bad and not outer_tilt_bad:
+        dominant = "outer shape response"
+    elif outer_tilt_bad and not outer_shape_bad:
+        dominant = "outer tilt response"
+    else:
+        dominant = "coupling"
+
+    totals = [float(case["total_energy"]) for case in cases]
+    zspans = [float(case["z_span"]) for case in cases]
+    if totals[0] < totals[1] < totals[2] and zspans[0] < zspans[1] < zspans[2]:
+        branch_reason = (
+            "the realized coupled energy genuinely favors a different branch"
+        )
+    else:
+        branch_reason = "the geometry solver/path is too stiff or constrained"
+
+    if dominant == "coupling":
+        recommendation = (
+            "Next stream should isolate the fixed-theta outer shape solve and shape-side "
+            "constraints/energy contributions on the curved free-disk lane, using forced theta_B near theory."
+        )
+    elif dominant == "outer shape response":
+        recommendation = "Next stream should isolate the outer geometry solve under fixed tilts and audit why the logarithmic trumpet shape is not realized."
+    else:
+        recommendation = "Next stream should isolate the outer leaflet transport/tilt discretization on the curved free-disk lane under fixed theta_B."
+
+    return {
+        "dominant_failure": dominant,
+        "near_rim_half_split_stays_good": bool(near_rim_good),
+        "branch_preference_interpretation": branch_reason,
+        "recommended_next_stream": recommendation,
+    }
+
+
+def pytest_approx_zero_placeholder() -> float:
+    """Return the exact zero threshold used in this diagnostic."""
+    return 1.0e-12
+
+
+def _run_forced_case(
+    theta_b: float, *, radius: float, lambda_theory: float
+) -> dict[str, object]:
+    """Run one forced theta_B case and return its diagnostic payload."""
+    result = _run_curved_theta_candidate(theta_b)
+    mesh = result["mesh"]
+    shell_rows = _shell_profile(mesh)
+    radii = [float(row["radius"]) for row in shell_rows]
+    max_radius = float(max(radii))
+    free_outer_radii = sorted(
+        rr for rr in radii if rr > float(radius) + 1.0e-6 and rr < max_radius - 1.0e-6
+    )
+    if not free_outer_radii:
+        raise AssertionError("Forced-theta diagnostic found no free outer shells.")
+    last_free_shell_radius = float(free_outer_radii[-1])
+    samples = _shell_vertex_samples(mesh)
+    near_rim_raw = dict(result["near_rim"])
+    half_theta = 0.5 * float(theta_b)
+    near_rim = {
+        **near_rim_raw,
+        "phi_over_theta_B": float(
+            abs(near_rim_raw["phi"]) / max(float(theta_b), 1.0e-12)
+        ),
+        "theta_in_over_half_theta_B": float(
+            near_rim_raw["theta_outer_in"] / max(abs(half_theta), 1.0e-12)
+        ),
+        "theta_out_over_half_theta_B": float(
+            near_rim_raw["theta_outer_out"] / max(abs(half_theta), 1.0e-12)
+        ),
+    }
+    outer_k1 = _outer_k1_summary(
+        shell_rows,
+        radius=radius,
+        lambda_theory=lambda_theory,
+        theta_b=theta_b,
+        last_free_shell_radius=last_free_shell_radius,
+    )
+    outer_height = _outer_height_summary(
+        shell_rows,
+        radius=radius,
+        theta_b=theta_b,
+        last_free_shell_radius=last_free_shell_radius,
+    )
+    outer_slope = _outer_slope_summary(
+        shell_rows,
+        radius=radius,
+        theta_b=theta_b,
+        last_free_shell_radius=last_free_shell_radius,
+    )
+    outer_curvature = _outer_curvature_diagnostic(
+        shell_rows, radius=radius, last_free_shell_radius=last_free_shell_radius
+    )
+    mismatch = _outer_leaflet_mismatch_summary(
+        shell_rows, radius=radius, last_free_shell_radius=last_free_shell_radius
+    )
+    energies = _compute_numeric_energy_split(mesh)
+    outer_elastic = {
+        "outer_elastic_numeric": float(energies["outer_elastic_numeric"]),
+        "outer_elastic_over_theta_B_sq": float(
+            float(energies["outer_elastic_numeric"]) / max(float(theta_b) ** 2, 1.0e-12)
+        ),
+    }
+    axisymmetry = _scatter_summary(
+        samples,
+        shell_rows,
+        radius=radius,
+        last_free_shell_radius=last_free_shell_radius,
+    )
+    return {
+        "theta_B": float(theta_b),
+        "phi_star_forced": float(0.5 * theta_b),
+        "total_energy": float(result["near_rim"]["total_energy"]),
+        "z_span": float(result["near_rim"]["z_span"]),
+        "last_free_shell_radius": float(last_free_shell_radius),
+        "near_rim": near_rim,
+        "outer_k1": outer_k1,
+        "outer_height_log": outer_height,
+        "outer_slope": outer_slope,
+        "outer_curvature": outer_curvature,
+        "outer_leaflet_mismatch": mismatch,
+        "outer_elastic": outer_elastic,
+        "axisymmetry": axisymmetry,
+    }
+
+
+def run_curved_1disk_forced_theta_diagnostic() -> dict[str, object]:
+    """Run the forced-theta curved diagnostic and return a JSON-serializable report."""
+    theory = compute_curved_disk_theory(tex_reference_params())
+    radius = float(theory.params.radius)
+    lambda_theory = float(theory.lambda_value)
+    cases = [
+        _run_forced_case(
+            theta_b=float(theta), radius=radius, lambda_theory=lambda_theory
+        )
+        for theta in FORCED_THETA_VALUES
+    ]
+    scaling_kind, scaling_stats = _classify_outer_elastic_scaling(cases)
+    for case in cases:
+        case["outer_elastic"]["scaling_classification"] = scaling_kind
+    diagnosis = _diagnose(cases, radius=radius)
+    return {
+        "forced_theta_values": [float(v) for v in FORCED_THETA_VALUES],
+        "theory": {
+            "R": radius,
+            "lambda_theory": lambda_theory,
+        },
+        "cases": cases,
+        "outer_elastic_scaling": {
+            "classification": scaling_kind,
+            **scaling_stats,
+        },
+        "diagnosis": diagnosis,
+    }
+
+
+def main() -> None:
+    """Run the forced-theta diagnostic and print JSON."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args()
+    report = run_curved_1disk_forced_theta_diagnostic()
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/diagnostics/curved_1disk_theory_benchmark.py
+++ b/tools/diagnostics/curved_1disk_theory_benchmark.py
@@ -1,0 +1,608 @@
+#!/usr/bin/env python3
+"""Curved 1-disk theory benchmark on the coupled tensionless free-disk lane."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+from scipy.special import i1, k1
+
+from geometry.curvature import compute_curvature_data, compute_curvature_fields
+from runtime.refinement import refine_triangle_mesh
+from tools.diagnostics.curved_disk_theory import (
+    CurvedDiskTheoryParams,
+    CurvedDiskTheoryResult,
+    compute_curved_disk_theory,
+    tex_reference_params,
+)
+from tools.diagnostics.free_disk_energy_split import (
+    _bending_tilt_energy,
+    _energy_breakdown,
+    _inner_leaflet_vertex_split,
+    _split_masks,
+    _tilt_energy,
+)
+from tools.diagnostics.free_disk_profile_fits import _fit_i1, _fit_k1, _fit_log
+from tools.diagnostics.free_disk_profile_protocol import (
+    DEFAULT_FREE_DISK_CURVED_BILAYER_SOURCE,
+    DEFAULT_FREE_DISK_FIXTURE,
+    _configure_shape_relax,
+    configure_free_disk_curved_bilayer_stage2,
+    load_free_disk_curved_bilayer_mesh,
+    load_free_disk_theory_mesh,
+    measure_free_disk_curved_bilayer_near_rim,
+    optimize_free_disk_theta_b,
+)
+
+REFINE_STEPS = 1
+THETA_SCANS = 4
+SHAPE_STEPS = 60
+THETA_OFFSETS = (-0.02, 0.0, 0.01, 0.02, 0.04, 0.06, 0.08, 0.10, 0.12, 0.14)
+INNER_I1_WINDOW = (0.25, 0.75)
+OUTER_K1_WINDOW = (2.0, 10.0)
+OUTER_LOG_WINDOW = (3.0, 10.0)
+K1_SENS_WINDOWS = ((2.0, 8.0), (2.0, 10.0), (2.0, 16.0))
+LOG_SENS_WINDOWS = ((3.0, 8.0), (3.0, 10.0), (3.0, 16.0))
+
+
+def _refine_once(mesh, *, steps: int = REFINE_STEPS):
+    """Return ``mesh`` refined ``steps`` times."""
+    for _ in range(int(steps)):
+        mesh = refine_triangle_mesh(mesh)
+    return mesh
+
+
+def _positions_radii(mesh) -> np.ndarray:
+    """Return radial distance in the xy plane for every vertex."""
+    return np.linalg.norm(mesh.positions_view()[:, :2], axis=1)
+
+
+def _shell_profile(mesh) -> list[dict[str, float]]:
+    """Return ring-median profile rows keyed by rounded radius."""
+    positions = mesh.positions_view()
+    radii = _positions_radii(mesh)
+    tilts_in = mesh.tilts_in_view()
+    tilts_out = mesh.tilts_out_view()
+    r_hat = np.zeros_like(positions)
+    good = radii > 1.0e-12
+    r_hat[good, 0] = positions[good, 0] / radii[good]
+    r_hat[good, 1] = positions[good, 1] / radii[good]
+    theta_in = np.einsum("ij,ij->i", tilts_in, r_hat)
+    theta_out = np.einsum("ij,ij->i", tilts_out, r_hat)
+
+    fields = compute_curvature_fields(mesh, positions, mesh.vertex_index_to_row)
+    mean_curvature = fields.mean_curvature
+
+    rows: list[dict[str, float]] = []
+    for radius_key in sorted({round(float(r), 6) for r in radii if r > 1.0e-12}):
+        mask = np.isclose(radii, float(radius_key), atol=1.0e-6)
+        if not np.any(mask):
+            continue
+        rows.append(
+            {
+                "radius": float(np.median(radii[mask])),
+                "theta_in": float(np.median(theta_in[mask])),
+                "theta_out": float(np.median(theta_out[mask])),
+                "theta_shared": float(
+                    0.5 * (np.median(theta_in[mask]) + np.median(theta_out[mask]))
+                ),
+                "z": float(np.median(positions[mask, 2])),
+                "J": float(np.median(mean_curvature[mask])),
+                "count": int(np.sum(mask)),
+            }
+        )
+    return rows
+
+
+def _window_rows(
+    shell_rows: list[dict[str, float]],
+    *,
+    radius: float,
+    window: tuple[float, float],
+    last_free_shell_radius: float,
+) -> list[dict[str, float]]:
+    """Return shell rows whose radius lies inside a benchmark window."""
+    r_lo = float(window[0]) * float(radius)
+    r_hi = min(float(window[1]) * float(radius), float(last_free_shell_radius) - 1.0e-6)
+    return [row for row in shell_rows if r_lo <= float(row["radius"]) <= r_hi]
+
+
+def _relative_rmse(y: np.ndarray, yhat: np.ndarray) -> float:
+    """Return RMSE normalized by the max signal magnitude."""
+    scale = max(float(np.max(np.abs(y))), 1.0e-12)
+    return float(np.sqrt(np.mean((y - yhat) ** 2)) / scale)
+
+
+def _fit_inner_i1(
+    shell_rows: list[dict[str, float]],
+    *,
+    radius: float,
+    lambda_theory: float,
+    last_free_shell_radius: float,
+) -> dict[str, object]:
+    """Fit the inner disk median tilt to the ``I1`` theory form."""
+    rows = _window_rows(
+        shell_rows,
+        radius=radius,
+        window=INNER_I1_WINDOW,
+        last_free_shell_radius=last_free_shell_radius,
+    )
+    r = np.asarray([float(row["radius"]) for row in rows], dtype=float)
+    y = np.asarray([float(row["theta_in"]) for row in rows], dtype=float)
+    amp, lam_fit, _ = _fit_i1(r, y, float(radius))
+    yhat = amp * i1(lam_fit * r) / i1(lam_fit * float(radius))
+    return {
+        "window": [float(INNER_I1_WINDOW[0]), float(INNER_I1_WINDOW[1])],
+        "count": int(len(r)),
+        "radii": [float(v) for v in r],
+        "amplitude_fit": float(amp),
+        "lambda_fit": float(lam_fit),
+        "lambda_ratio": float(lam_fit / lambda_theory),
+        "rel_rmse": _relative_rmse(y, yhat),
+    }
+
+
+def _fit_outer_k1(
+    shell_rows: list[dict[str, float]],
+    *,
+    radius: float,
+    lambda_theory: float,
+    last_free_shell_radius: float,
+    window: tuple[float, float],
+) -> dict[str, object]:
+    """Fit the shared outer tilt to the ``K1`` theory form."""
+    rows = _window_rows(
+        shell_rows,
+        radius=radius,
+        window=window,
+        last_free_shell_radius=last_free_shell_radius,
+    )
+    r = np.asarray([float(row["radius"]) for row in rows], dtype=float)
+    y_in = np.asarray([float(row["theta_in"]) for row in rows], dtype=float)
+    y_out = np.asarray([float(row["theta_out"]) for row in rows], dtype=float)
+    y = 0.5 * (y_in + y_out)
+    amp, lam_fit, _ = _fit_k1(r, y, float(radius))
+    yhat = amp * k1(lam_fit * r) / k1(lam_fit * float(radius))
+    signal = np.maximum(np.abs(y), 1.0e-12)
+    leaflet_mismatch = np.median(np.abs(y_in - y_out) / signal)
+    return {
+        "window": [float(window[0]), float(window[1])],
+        "count": int(len(r)),
+        "radii": [float(v) for v in r],
+        "amplitude_fit": float(amp),
+        "lambda_fit": float(lam_fit),
+        "lambda_ratio": float(lam_fit / lambda_theory),
+        "rel_rmse": _relative_rmse(y, yhat),
+        "leaflet_mismatch_median": float(leaflet_mismatch),
+    }
+
+
+def _fit_outer_log_height(
+    shell_rows: list[dict[str, float]],
+    *,
+    radius: float,
+    slope_theory: float,
+    last_free_shell_radius: float,
+    window: tuple[float, float],
+) -> dict[str, object]:
+    """Fit the outer shell-median height to the tensionless logarithmic law."""
+    rows = _window_rows(
+        shell_rows,
+        radius=radius,
+        window=window,
+        last_free_shell_radius=last_free_shell_radius,
+    )
+    r = np.asarray([float(row["radius"]) for row in rows], dtype=float)
+    z = np.asarray([float(row["z"]) for row in rows], dtype=float)
+    z0, slope_fit, _ = _fit_log(r, z, float(radius))
+    zhat = z0 + slope_fit * np.log(r / float(radius))
+    return {
+        "window": [float(window[0]), float(window[1])],
+        "count": int(len(r)),
+        "radii": [float(v) for v in r],
+        "z0_fit": float(z0),
+        "slope_fit": float(slope_fit),
+        "slope_ratio": float(slope_fit / slope_theory),
+        "rel_rmse": _relative_rmse(z, zhat),
+    }
+
+
+def _outer_curvature_summary(
+    shell_rows: list[dict[str, float]],
+    *,
+    radius: float,
+    last_free_shell_radius: float,
+) -> dict[str, float]:
+    """Return mean and tail curvature summary on the free outer membrane."""
+    rows = [
+        row
+        for row in shell_rows
+        if float(row["radius"]) > float(radius) + 1.0e-6
+        and float(row["radius"]) < float(last_free_shell_radius) + 1.0e-6
+    ]
+    abs_j = np.asarray([abs(float(row["J"])) for row in rows], dtype=float)
+    return {
+        "count": int(abs_j.size),
+        "mean_abs_J": float(np.mean(abs_j)) if abs_j.size else 0.0,
+        "p95_abs_J": float(np.percentile(abs_j, 95.0)) if abs_j.size else 0.0,
+    }
+
+
+def _compute_numeric_energy_split(mesh) -> dict[str, float]:
+    """Return the disk/outer/contact split for the final curved benchmark mesh."""
+    positions = mesh.positions_view()
+    tri_rows_full, _ = mesh.triangle_row_cache()
+    if tri_rows_full is None or tri_rows_full.size == 0:
+        raise ValueError("No triangles found in benchmark mesh.")
+
+    _, _, weights_full, tri_rows_curv = compute_curvature_data(
+        mesh, positions, mesh.vertex_index_to_row
+    )
+    if tri_rows_curv.shape[0] != tri_rows_full.shape[0]:
+        raise ValueError("Triangle rows mismatch between caches.")
+
+    inner_split = _inner_leaflet_vertex_split(
+        mesh=mesh,
+        positions=positions,
+        tri_rows_full=tri_rows_full,
+        weights_full=weights_full,
+    )
+    tri_mask_disk, tri_mask_outer = _split_masks(mesh, tri_rows_full)
+    del tri_mask_disk  # Disk contribution is already carried by the inner split.
+
+    tilt_out_outer = _tilt_energy(
+        positions=positions,
+        tri_rows=tri_rows_full[tri_mask_outer],
+        tilts=mesh.tilts_out_view(),
+        k_tilt=float(mesh.global_parameters.get("tilt_modulus_out") or 0.0),
+    )
+    bend_out_outer = _bending_tilt_energy(
+        mesh=mesh,
+        global_params=mesh.global_parameters,
+        positions=positions,
+        tri_rows_full=tri_rows_full,
+        weights_full=weights_full,
+        tri_mask=tri_mask_outer,
+        tilts=mesh.tilts_out_view(),
+        kappa_key="bending_modulus_out",
+        cache_tag="out",
+    )
+
+    breakdown = _energy_breakdown(mesh)
+    contact = float(breakdown.get("tilt_thetaB_contact_in") or 0.0)
+    disk_total = float(inner_split["tilt_in_disk"]) + float(
+        inner_split["bending_tilt_in_disk"]
+    )
+    outer_total = (
+        float(inner_split["tilt_in_outer"])
+        + float(inner_split["bending_tilt_in_outer"])
+        + float(tilt_out_outer)
+        + float(bend_out_outer)
+    )
+    return {
+        "total_numeric": float(sum(float(v) for v in breakdown.values())),
+        "inner_elastic_numeric": float(disk_total),
+        "outer_elastic_numeric": float(outer_total),
+        "contact_numeric": float(contact),
+    }
+
+
+def _run_curved_theta_candidate(
+    theta_b: float,
+    *,
+    curved_path: str | Path | None = None,
+) -> dict[str, object]:
+    """Run one refined curved candidate and return mesh, near-rim stats, and energy."""
+    mesh = _refine_once(load_free_disk_curved_bilayer_mesh(curved_path))
+    configure_free_disk_curved_bilayer_stage2(mesh, theta_b=float(theta_b), z_bump=None)
+    minim = _configure_shape_relax(mesh, theta_b=float(theta_b))
+    minim.minimize(n_steps=SHAPE_STEPS)
+    breakdown = minim.compute_energy_breakdown()
+    row = measure_free_disk_curved_bilayer_near_rim(mesh, theta_b=float(theta_b))
+    row["total_energy"] = float(sum(float(v) for v in breakdown.values()))
+    return {"mesh": mesh, "near_rim": row, "breakdown": breakdown}
+
+
+def _run_canonical_schedule(
+    *,
+    theta_path: str | Path | None = None,
+    curved_path: str | Path | None = None,
+) -> dict[str, object]:
+    """Run the benchmark's exact three-stage canonical schedule."""
+    theta_mesh = _refine_once(load_free_disk_theory_mesh(theta_path))
+    theta_seed = float(optimize_free_disk_theta_b(theta_mesh, scans=THETA_SCANS))
+    theta_values = sorted(
+        {
+            round(max(0.0, float(theta_seed) + float(delta)), 8)
+            for delta in THETA_OFFSETS
+        }
+    )
+
+    sweep_rows: list[dict[str, float]] = []
+    best_theta_b = None
+    best_total_energy = None
+    for theta_b in theta_values:
+        result = _run_curved_theta_candidate(theta_b, curved_path=curved_path)
+        row = dict(result["near_rim"])
+        row["total_energy"] = float(row["total_energy"])
+        sweep_rows.append(row)
+        if best_total_energy is None or float(row["total_energy"]) < best_total_energy:
+            best_total_energy = float(row["total_energy"])
+            best_theta_b = float(theta_b)
+
+    if best_theta_b is None:
+        raise AssertionError("Curved local theta scan produced no valid candidate.")
+
+    final = _run_curved_theta_candidate(best_theta_b, curved_path=curved_path)
+    return {
+        "theta_seed": float(theta_seed),
+        "theta_values": [float(v) for v in theta_values],
+        "theta_sweep_rows": sweep_rows,
+        "theta_B_selected": float(best_theta_b),
+        "theta_selected_energy": float(best_total_energy),
+        "mesh": final["mesh"],
+        "near_rim": dict(final["near_rim"]),
+    }
+
+
+def _outer_window_sensitivity(
+    shell_rows: list[dict[str, float]],
+    *,
+    radius: float,
+    lambda_theory: float,
+    slope_theory: float,
+    last_free_shell_radius: float,
+) -> dict[str, object]:
+    """Return the explicit outer-window sensitivity audit required for lock."""
+    k1_fits = [
+        _fit_outer_k1(
+            shell_rows,
+            radius=radius,
+            lambda_theory=lambda_theory,
+            last_free_shell_radius=last_free_shell_radius,
+            window=window,
+        )
+        for window in K1_SENS_WINDOWS
+    ]
+    log_fits = [
+        _fit_outer_log_height(
+            shell_rows,
+            radius=radius,
+            slope_theory=slope_theory,
+            last_free_shell_radius=last_free_shell_radius,
+            window=window,
+        )
+        for window in LOG_SENS_WINDOWS
+    ]
+
+    primary_lambda = float(k1_fits[1]["lambda_fit"])
+    primary_slope = float(log_fits[1]["slope_fit"])
+    lambda_values = np.asarray(
+        [float(row["lambda_fit"]) for row in k1_fits], dtype=float
+    )
+    slope_values = np.asarray(
+        [float(row["slope_fit"]) for row in log_fits], dtype=float
+    )
+    lambda_spread = float(
+        (np.max(lambda_values) - np.min(lambda_values))
+        / max(abs(primary_lambda), 1.0e-12)
+    )
+    slope_spread = float(
+        (np.max(slope_values) - np.min(slope_values)) / max(abs(primary_slope), 1.0e-12)
+    )
+    return {
+        "outer_k1_windows": k1_fits,
+        "outer_log_windows": log_fits,
+        "lambda_fit_spread": lambda_spread,
+        "log_slope_spread": slope_spread,
+    }
+
+
+def _theory_summary(theory: CurvedDiskTheoryResult) -> dict[str, float]:
+    """Return the benchmark theory targets as a flat serializable mapping."""
+    return {
+        "radius": float(theory.params.radius),
+        "drive": float(theory.params.drive),
+        "kappa": float(theory.params.kappa),
+        "kappa_t": float(theory.params.kappa_t),
+        "surface_tension": float(theory.params.surface_tension),
+        "lambda_theory": float(theory.lambda_value),
+        "theta_B_opt": float(theory.theta_star),
+        "phi_star": float(theory.phi_star),
+        "F_in_el": float(theory.elastic_inner),
+        "F_out_el": float(theory.elastic_outer),
+        "F_cont": float(theory.contact),
+        "F_tot": float(theory.total),
+    }
+
+
+def run_curved_1disk_theory_benchmark(
+    *,
+    theta_path: str | Path | None = None,
+    curved_path: str | Path | None = None,
+    theory_params: CurvedDiskTheoryParams | None = None,
+) -> dict[str, object]:
+    """Run the full curved 1-disk benchmark and return a report dictionary."""
+    params = theory_params or tex_reference_params()
+    theory = compute_curved_disk_theory(params)
+    schedule = _run_canonical_schedule(theta_path=theta_path, curved_path=curved_path)
+    mesh = schedule["mesh"]
+    shell_rows = _shell_profile(mesh)
+
+    radius = float(params.radius)
+    radii = [float(row["radius"]) for row in shell_rows]
+    max_radius = float(max(radii))
+    free_outer_radii = sorted(
+        rr for rr in radii if rr > radius + 1.0e-6 and rr < max_radius - 1.0e-6
+    )
+    if not free_outer_radii:
+        raise AssertionError("Benchmark mesh has no free outer shells.")
+    last_free_shell_radius = float(free_outer_radii[-1])
+
+    near_rim_raw = dict(schedule["near_rim"])
+    half_theta = 0.5 * float(schedule["theta_B_selected"])
+    near_rim = {
+        **near_rim_raw,
+        "phi_over_theta_B": float(
+            abs(near_rim_raw["phi"]) / max(float(schedule["theta_B_selected"]), 1.0e-12)
+        ),
+        "theta_in_over_half_theta_B": float(
+            near_rim_raw["theta_outer_in"] / max(abs(half_theta), 1.0e-12)
+        ),
+        "theta_out_over_half_theta_B": float(
+            near_rim_raw["theta_outer_out"] / max(abs(half_theta), 1.0e-12)
+        ),
+    }
+
+    fits = {
+        "inner_i1": _fit_inner_i1(
+            shell_rows,
+            radius=radius,
+            lambda_theory=float(theory.lambda_value),
+            last_free_shell_radius=last_free_shell_radius,
+        ),
+        "outer_k1": _fit_outer_k1(
+            shell_rows,
+            radius=radius,
+            lambda_theory=float(theory.lambda_value),
+            last_free_shell_radius=last_free_shell_radius,
+            window=OUTER_K1_WINDOW,
+        ),
+        "outer_height_log": _fit_outer_log_height(
+            shell_rows,
+            radius=radius,
+            slope_theory=float(theory.phi_star) * radius,
+            last_free_shell_radius=last_free_shell_radius,
+            window=OUTER_LOG_WINDOW,
+        ),
+    }
+    outer_sensitivity = _outer_window_sensitivity(
+        shell_rows,
+        radius=radius,
+        lambda_theory=float(theory.lambda_value),
+        slope_theory=float(theory.phi_star) * radius,
+        last_free_shell_radius=last_free_shell_radius,
+    )
+    curvature = _outer_curvature_summary(
+        shell_rows, radius=radius, last_free_shell_radius=last_free_shell_radius
+    )
+    energies = _compute_numeric_energy_split(mesh)
+
+    failures: list[str] = []
+    theta_b_num = float(schedule["theta_B_selected"])
+    if not np.isclose(theta_b_num, float(theory.theta_star), rtol=0.10, atol=0.0):
+        failures.append("theta_B_opt")
+    if not np.isclose(float(near_rim["phi_over_theta_B"]), 0.5, rtol=0.10, atol=0.0):
+        failures.append("phi_star_ratio")
+    if not np.isclose(
+        float(near_rim["theta_in_over_half_theta_B"]), 1.0, rtol=0.15, atol=0.0
+    ):
+        failures.append("theta_in_half_split")
+    if not np.isclose(
+        float(near_rim["theta_out_over_half_theta_B"]), 1.0, rtol=0.15, atol=0.0
+    ):
+        failures.append("theta_out_half_split")
+    if (
+        not np.isclose(
+            float(fits["inner_i1"]["lambda_fit"]), float(theory.lambda_value), rtol=0.10
+        )
+        or float(fits["inner_i1"]["rel_rmse"]) > 0.05
+    ):
+        failures.append("inner_i1_fit")
+    if (
+        not np.isclose(
+            float(fits["outer_k1"]["lambda_fit"]), float(theory.lambda_value), rtol=0.10
+        )
+        or float(fits["outer_k1"]["rel_rmse"]) > 0.05
+        or float(fits["outer_k1"]["leaflet_mismatch_median"]) > 0.05
+    ):
+        failures.append("outer_k1_fit")
+    if (
+        not np.isclose(
+            float(fits["outer_height_log"]["slope_fit"]),
+            float(theory.phi_star) * radius,
+            rtol=0.15,
+        )
+        or float(fits["outer_height_log"]["rel_rmse"]) > 0.20
+    ):
+        failures.append("outer_height_log_fit")
+    if float(curvature["mean_abs_J"]) > 0.05 or float(curvature["p95_abs_J"]) > 0.15:
+        failures.append("outer_curvature")
+    if not np.isclose(
+        float(energies["total_numeric"]), float(theory.total), rtol=0.10, atol=0.0
+    ):
+        failures.append("total_energy")
+    if not np.isclose(
+        float(energies["inner_elastic_numeric"]),
+        float(theory.elastic_inner),
+        rtol=0.15,
+        atol=0.0,
+    ):
+        failures.append("inner_elastic")
+    if not np.isclose(
+        float(energies["outer_elastic_numeric"]),
+        float(theory.elastic_outer),
+        rtol=0.15,
+        atol=0.0,
+    ):
+        failures.append("outer_elastic")
+    if not np.isclose(
+        float(energies["contact_numeric"]), float(theory.contact), rtol=0.15, atol=0.0
+    ):
+        failures.append("contact_energy")
+    if float(outer_sensitivity["lambda_fit_spread"]) > 0.10:
+        failures.append("outer_k1_window_sensitivity")
+    if float(outer_sensitivity["log_slope_spread"]) > 0.10:
+        failures.append("outer_log_window_sensitivity")
+
+    return {
+        "canonical_schedule": {
+            "theta_scans": THETA_SCANS,
+            "theta_offsets": [float(v) for v in THETA_OFFSETS],
+            "shape_steps": SHAPE_STEPS,
+            "refine_steps": REFINE_STEPS,
+        },
+        "theory": _theory_summary(theory),
+        "theta_seed": float(schedule["theta_seed"]),
+        "theta_values": [float(v) for v in schedule["theta_values"]],
+        "theta_sweep_rows": schedule["theta_sweep_rows"],
+        "theta_B_selected": float(schedule["theta_B_selected"]),
+        "near_rim": near_rim,
+        "fits": fits,
+        "outer_curvature": curvature,
+        "energies": energies,
+        "outer_window_sensitivity": outer_sensitivity,
+        "last_free_shell_radius": float(last_free_shell_radius),
+        "shell_rows": shell_rows,
+        "benchmark_lock_failures": failures,
+        "benchmark_lock_passed": not failures,
+    }
+
+
+def main() -> None:
+    """Run the benchmark and print a JSON report."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--theta-path",
+        default=str(DEFAULT_FREE_DISK_FIXTURE),
+        help="Path to the theory/theta fixture YAML.",
+    )
+    parser.add_argument(
+        "--curved-path",
+        default=str(DEFAULT_FREE_DISK_CURVED_BILAYER_SOURCE),
+        help="Path to the curved free-disk source YAML.",
+    )
+    args = parser.parse_args()
+
+    report = run_curved_1disk_theory_benchmark(
+        theta_path=args.theta_path,
+        curved_path=args.curved_path,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a curved 1-disk benchmark report for the current canonical coupled tensionless path
- add a diagnostic-only benchmark test that records the current benchmark miss instead of locking a false pass
- add a forced-`theta_B` curved diagnostic for `0.06`, `0.12`, and `0.1845693593`
- keep this PR diagnostic-only: no fixes, no threshold changes, and no docs updates

## Motivation / Context
- the curved 1-disk theory case from `1_disk_3d.tex` is the next higher-value non-Stage-A target
- current `main` does not lock that benchmark on the canonical path
- this PR makes that miss explicit and localized
- the forced-`theta_B` diagnostic shows the miss is downstream of rim matching and is best interpreted as a coupled outer shape/tilt response problem

## Design Notes
- Feature contract link/summary:
  - benchmark/report only; no runtime or main-flow changes
  - first report encodes the exact canonical curved benchmark path and current miss
  - second report isolates fixed-`theta_B` curved response at low, intermediate, and theory values
- Interfaces changed (if any):
  - adds two diagnostic tools under `tools/diagnostics/`
  - adds two slow benchmark-style tests under `tests/`
- Invariants enforced:
  - no Stage A changes
  - no support/operator redesign changes
  - no benchmark-window tuning, no lock-criteria changes, no docs changes
  - carried benchmark/report remains unchanged while the forced-`theta_B` diagnostic is added on top

## How to Test
```bash
pytest -q -o addopts='' tests/test_curved_1disk_theory_benchmark.py
pytest -q -o addopts='' tests/test_curved_1disk_forced_theta_diagnostic.py
pytest -q tests/test_bending_tilt_leaflet_stage_a_outer_grad_linear_transition_regression.py tests/test_stage_a_emergent.py tests/test_stage_a_fixture_builder.py
pytest -q tests/test_flat_disk_one_leaflet_theory_unit.py tests/test_flat_disk_kh_outer_vertex_audit_regression.py tests/test_flat_disk_kh_term_audit_regression.py tests/test_flat_disk_one_leaflet_benchmark_e2e.py -k 'kh_physical or benchmark_reference or reference_values or reports_finite_rows or screening_resolution'
```
- Targeted reproduction:
  - `python tools/diagnostics/curved_1disk_theory_benchmark.py`
  - `python tools/diagnostics/curved_1disk_forced_theta_diagnostic.py`

## Risks & Mitigations
- risk: diagnostic tests could accidentally encode a fix or alter benchmark thresholds
  - mitigation: this PR does not change thresholds, fit windows, docs, or runtime behavior
- risk: broad curved acceptance lanes are noisy and could be confused with the new benchmark path
  - mitigation: validation is kept to the scoped diagnostic tests plus existing Stage A / flat-KH guardrails

## Performance / Benchmarks (if relevant)
- no runtime-path performance change
- benchmark findings from the forced-`theta_B` diagnostic:
  - near-rim continuation stays good across all forced cases
  - outer `K1` and outer log-height responses both miss strongly
  - outer curvature grows with forced `theta_B`
  - outer elastic scaling is still approximately quadratic
- interpretation:
  - the curved 1-disk miss is downstream of rim matching and is best understood as a coupled outer shape/tilt response problem

## Assumptions / Open Questions
- this PR intentionally stops at diagnosis; it does not attempt a fix
- next follow-up should isolate the fixed-`theta_B` outer shape solve and shape-side constraints/energy contributions near the theory value
- the carried curved benchmark/report is local work being landed here together with the forced-`theta_B` diagnostic so the next stream has a stable baseline
