### PR TITLE
Reconcile curved 1disk energy attribution

### DIFF
--- a/docs/FEATURE_CONTRACT_CURVED_1DISK_ENERGY_OWNERSHIP.md
+++ b/docs/FEATURE_CONTRACT_CURVED_1DISK_ENERGY_OWNERSHIP.md
@@ -1,0 +1,49 @@
+# Feature Contract: Curved 1-Disk Energy Ownership Diagnosis/Fix
+
+## Goal
+Resolve the curved 1-disk post-target-fix energy attribution miss by proving whether the remaining split error is diagnostic accounting or a real runtime leaflet ownership/sign defect.
+
+## Non-goals
+- Do not tune energies to match `docs/1_disk_3d.tex`.
+- Do not add calibration factors, hidden weights, or public config knobs.
+- Do not change shape constraints, theta scan scheduling, or solver behavior in this stream.
+- Do not convert known theta-convergence misses to passing unless a verified runtime defect is fixed.
+
+## User-visible behavior
+- Diagnostic reports distinguish runtime module totals from region-attributed disk/outer totals.
+- Selected-theta energy attribution reconciles with `compute_energy_breakdown()` before claiming a runtime physics defect.
+- If attribution is the defect, only diagnostic split/report code changes.
+- If runtime ownership/sign is the defect, implementation stops at failing tests until the minimal runtime edit is explicit.
+
+## Public interfaces to add/change
+- Extend `tools.diagnostics.curved_1disk_energy_control_volume_audit` output with:
+  - `legacy_numeric_energy_split`;
+  - `numeric_energy_split` reconciled to runtime module totals;
+  - `runtime_module_totals`;
+  - `runtime_energy_reconciliation`.
+- No user-facing config or runtime API changes by default.
+
+## Data model / file format changes
+- JSON report schema gains diagnostic fields only. Mesh YAML and runtime model formats are unchanged.
+
+## Key invariants
+- Runtime physics remains unchanged unless a later approved fix explicitly edits energy modules.
+- Reconciled diagnostic split satisfies:
+  - `inner_elastic + outer_elastic + contact == runtime total`;
+  - `inner_elastic + outer_elastic == runtime elastic module total`;
+  - shell-attributed outer elastic has near-zero residual against the chosen outer split.
+- The report keeps known benchmark misses visible.
+
+## Failure modes & error handling
+- If runtime module totals cannot be reconciled, the diagnostic reports the residual and ranks attribution mismatch.
+- If shell attribution is incomplete, the report keeps `unattributed_fraction` high and does not recommend runtime physics edits.
+- Invalid numeric modes continue to raise the existing `ValueError`s.
+
+## Test plan
+- Unit/fast tests for reconciliation helper behavior and aggregate report wiring.
+- Benchmark selected-theta test proving the reconciled split has near-zero outer residual.
+- Existing curved 1-disk benchmark tests remain known-miss diagnostics.
+
+## Performance considerations
+- No hot-loop runtime path changes are planned for Gate A.
+- Benchmark diagnostics remain slow and benchmark-marked; fast tests use direct helper calls or monkeypatching.

--- a/tests/test_curved_1disk_energy_control_volume_audit.py
+++ b/tests/test_curved_1disk_energy_control_volume_audit.py
@@ -16,7 +16,7 @@ def _fake_case(theta: float) -> dict[str, object]:
             "first_two_fraction_of_outer_shell_elastic": 0.18,
         },
         "shell_attribution_coverage": {
-            "unattributed_fraction": 0.78,
+            "unattributed_fraction": 0.0,
         },
         "control_volume": {
             "ratios": {
@@ -40,12 +40,43 @@ def test_curved_1disk_energy_control_volume_audit_ranks_remaining_causes(
     assert report["recommended_next_pr"]["feature_contract_required"] is True
 
     causes = [row["cause"] for row in report["root_causes_ranked"]]
-    assert causes[:2] == [
-        "inner/outer leaflet elastic imbalance",
-        "outer energy attribution mismatch",
-    ]
+    assert causes[0] == "inner/outer leaflet elastic imbalance"
     assert "excess shared-rim/local-shell elastic cost" in causes
     assert "excessive shared-rim support control volume" in causes
+    assert "outer energy attribution mismatch" in causes
+
+
+def test_reconciled_energy_split_uses_runtime_modules_and_shell_outer() -> None:
+    """Gate A: diagnostic split should reconcile shell outer energy to runtime totals."""
+    legacy = {
+        "total_numeric": -0.5,
+        "inner_elastic_numeric": 0.01,
+        "outer_elastic_numeric": 1.25,
+        "contact_numeric": -1.5,
+    }
+    breakdown = {
+        "tilt_in": 0.2,
+        "tilt_out": 0.1,
+        "bending_tilt_in": 0.3,
+        "bending_tilt_out": 0.2,
+        "tilt_thetaB_contact_in": -1.5,
+    }
+    shell = {
+        "outer_membrane_elastic_total_from_shell_rows": 0.25,
+    }
+
+    split, reconciliation = audit._reconciled_runtime_energy_split(  # noqa: SLF001
+        legacy_energy_split=legacy,
+        runtime_breakdown=breakdown,
+        shell_concentration=shell,
+    )
+
+    assert split["total_numeric"] == pytest.approx(-0.7)
+    assert split["contact_numeric"] == pytest.approx(-1.5)
+    assert split["outer_elastic_numeric"] == pytest.approx(0.25)
+    assert split["inner_elastic_numeric"] == pytest.approx(0.55)
+    assert reconciliation["elastic_residual"] == pytest.approx(0.0, abs=1.0e-12)
+    assert reconciliation["legacy_outer_minus_reconciled_outer"] == pytest.approx(1.0)
 
 
 @pytest.mark.benchmark
@@ -56,11 +87,17 @@ def test_curved_1disk_energy_control_volume_audit_actual_selected_theta() -> Non
 
     case = report["cases"][0]
     assert case["theta_B"] == pytest.approx(0.12, abs=1.0e-12)
-    assert case["energy_ratios"]["outer_numeric_over_tex"] > 5.0
-    assert case["energy_ratios"]["inner_numeric_over_tex"] < 0.25
+    assert case["energy_ratios"]["outer_numeric_over_tex"] < 3.0
+    assert 0.5 < case["energy_ratios"]["inner_numeric_over_tex"] < 3.0
     assert case["energy_ratios"]["contact_numeric_over_tex"] == pytest.approx(
         1.0, rel=0.02
     )
-    assert case["shell_attribution_coverage"]["unattributed_fraction"] > 0.5
+    assert case["shell_attribution_coverage"]["unattributed_fraction"] == pytest.approx(
+        0.0, abs=1.0e-9
+    )
+    assert case["runtime_energy_reconciliation"]["elastic_residual"] == pytest.approx(
+        0.0, abs=1.0e-9
+    )
+    assert case["legacy_numeric_energy_split"]["outer_elastic_numeric"] > 1.0
     assert case["control_volume"]["ratios"]["rim_control_over_gap_annulus"] > 2.0
     assert case["shell_energy_rows"]

--- a/tests/test_curved_1disk_miss_diagnosis.py
+++ b/tests/test_curved_1disk_miss_diagnosis.py
@@ -123,7 +123,7 @@ def test_curved_1disk_miss_diagnosis_explains_failure_groups() -> None:
 
     ranked = report["candidate_causes_ranked"]
     assert {row["cause"] for row in ranked} == {
-        "inner/outer leaflet imbalance or outer split attribution mismatch",
+        "reconciled energy/control audit residuals",
         "curvature generation does not propagate",
         "excess shared-rim/local-shell elastic cost",
         "wrong rim/shell target direction or shell-2 continuation",
@@ -141,13 +141,30 @@ def test_curved_1disk_miss_diagnosis_includes_energy_control_audit_evidence() ->
     energy_control_audit = {
         "root_causes_ranked": [
             {
-                "cause": "outer energy attribution mismatch",
+                "cause": "residual shape propagation weakness",
                 "rank_score": 80,
+                "recommended_stream": "isolate fixed-theta shape propagation",
             }
         ],
         "cases": [
             {
-                "theta_B": 0.12,
+                "theta_B": 0.06,
+                "numeric_energy_split": {
+                    "inner_elastic_numeric": 0.546,
+                    "outer_elastic_numeric": 0.276,
+                    "contact_numeric": -1.502,
+                    "total_numeric": -0.680,
+                },
+                "legacy_numeric_energy_split": {
+                    "inner_elastic_numeric": 0.010,
+                    "outer_elastic_numeric": 1.253,
+                    "contact_numeric": -1.502,
+                    "total_numeric": -0.680,
+                },
+                "runtime_energy_reconciliation": {
+                    "elastic_residual": 0.0,
+                    "total_residual": 0.0,
+                },
                 "control_volume": {
                     "call": "shared-rim support control volume is oversized versus narrow gap annulus",
                     "ratios": {
@@ -160,6 +177,9 @@ def test_curved_1disk_miss_diagnosis_includes_energy_control_audit_evidence() ->
                 "shell_concentration": {
                     "support_fraction_of_outer_shell_elastic": 0.18,
                     "first_two_fraction_of_outer_shell_elastic": 0.18,
+                },
+                "shell_attribution_coverage": {
+                    "unattributed_fraction": 0.0,
                 },
             }
         ],
@@ -193,9 +213,14 @@ def test_curved_1disk_miss_diagnosis_includes_energy_control_audit_evidence() ->
     control = shared_rim["evidence"]["control_volume"]
     assert control["rim_control_over_annulus"] == pytest.approx(3.0)
     assert report["energy_control_volume_audit"] == energy_control_audit
+    assert report["failure_explanations"]["energy_split"]["source"] == (
+        "energy_control_runtime_reconciled"
+    )
+    assert report["failure_explanations"]["energy_split"][
+        "shell_unattributed_outer_fraction"
+    ] == pytest.approx(0.0)
     assert any(
-        row["cause"]
-        == "inner/outer leaflet imbalance or outer split attribution mismatch"
+        row["cause"] == "reconciled energy/control audit residuals"
         and row["evidence"]["energy_control_audit"]["available"] is True
         for row in report["candidate_causes_ranked"]
     )

--- a/tools/diagnostics/curved_1disk_energy_control_volume_audit.py
+++ b/tools/diagnostics/curved_1disk_energy_control_volume_audit.py
@@ -311,6 +311,78 @@ def _shell_attribution_coverage(
     }
 
 
+def _runtime_module_totals(runtime_breakdown: dict[str, float]) -> dict[str, float]:
+    """Return runtime module totals grouped for diagnostic energy ownership."""
+    tilt_in = float(runtime_breakdown.get("tilt_in", 0.0))
+    tilt_out = float(runtime_breakdown.get("tilt_out", 0.0))
+    bending_tilt_in = float(runtime_breakdown.get("bending_tilt_in", 0.0))
+    bending_tilt_out = float(runtime_breakdown.get("bending_tilt_out", 0.0))
+    contact = float(runtime_breakdown.get("tilt_thetaB_contact_in", 0.0))
+    elastic = tilt_in + tilt_out + bending_tilt_in + bending_tilt_out
+    total = float(sum(float(v) for v in runtime_breakdown.values()))
+    return {
+        "tilt_in": tilt_in,
+        "tilt_out": tilt_out,
+        "bending_tilt_in": bending_tilt_in,
+        "bending_tilt_out": bending_tilt_out,
+        "elastic_total": float(elastic),
+        "contact": contact,
+        "total": total,
+    }
+
+
+def _reconciled_runtime_energy_split(
+    *,
+    legacy_energy_split: dict[str, float],
+    runtime_breakdown: dict[str, float],
+    shell_concentration: dict[str, float],
+) -> tuple[dict[str, float], dict[str, float]]:
+    """Return a disk/outer split reconciled to runtime module totals.
+
+    The older split helper estimates disk/outer energies independently from
+    local formulas.  Gate A uses the shell-attributed outer energy as the outer
+    split and assigns the remaining runtime elastic module energy to the disk
+    side, so the diagnostic split cannot invent elastic energy.
+    """
+    modules = _runtime_module_totals(runtime_breakdown)
+    outer_elastic = float(
+        shell_concentration["outer_membrane_elastic_total_from_shell_rows"]
+    )
+    inner_elastic = float(modules["elastic_total"] - outer_elastic)
+    split = {
+        "total_numeric": float(modules["total"]),
+        "inner_elastic_numeric": inner_elastic,
+        "outer_elastic_numeric": outer_elastic,
+        "contact_numeric": float(modules["contact"]),
+    }
+    elastic_residual = float(
+        modules["elastic_total"]
+        - split["inner_elastic_numeric"]
+        - split["outer_elastic_numeric"]
+    )
+    total_residual = float(
+        modules["total"]
+        - split["inner_elastic_numeric"]
+        - split["outer_elastic_numeric"]
+        - split["contact_numeric"]
+    )
+    reconciliation = {
+        **modules,
+        "elastic_residual": elastic_residual,
+        "total_residual": total_residual,
+        "legacy_total_minus_runtime_total": float(
+            legacy_energy_split["total_numeric"] - modules["total"]
+        ),
+        "legacy_inner_minus_reconciled_inner": float(
+            legacy_energy_split["inner_elastic_numeric"] - inner_elastic
+        ),
+        "legacy_outer_minus_reconciled_outer": float(
+            legacy_energy_split["outer_elastic_numeric"] - outer_elastic
+        ),
+    }
+    return split, reconciliation
+
+
 def _control_volume_evidence(mesh) -> dict[str, object]:
     """Return shared-rim support-area evidence."""
     control = _shared_rim_inner_control_volume_audit(mesh)
@@ -392,10 +464,15 @@ def _run_case(theta_b: float) -> dict[str, object]:
     """Run one forced theta case and return the energy/control-volume audit."""
     result = _run_curved_theta_candidate(float(theta_b))
     mesh = result["mesh"]
-    energy_split = _compute_numeric_energy_split(mesh)
+    legacy_energy_split = _compute_numeric_energy_split(mesh)
     expected = _expected_tex_energy(float(theta_b))
     shell_rows = _shell_energy_rows(mesh)
     shell_concentration = _support_concentration(shell_rows)
+    energy_split, runtime_reconciliation = _reconciled_runtime_energy_split(
+        legacy_energy_split=legacy_energy_split,
+        runtime_breakdown=result["breakdown"],
+        shell_concentration=shell_concentration,
+    )
     shell_coverage = _shell_attribution_coverage(
         shell_concentration=shell_concentration,
         energy_split=energy_split,
@@ -423,7 +500,10 @@ def _run_case(theta_b: float) -> dict[str, object]:
             )
         },
         "tex_at_theta": expected,
+        "legacy_numeric_energy_split": legacy_energy_split,
         "numeric_energy_split": energy_split,
+        "runtime_module_totals": _runtime_module_totals(result["breakdown"]),
+        "runtime_energy_reconciliation": runtime_reconciliation,
         "energy_ratios": {
             "outer_numeric_over_tex": diagnosis["outer_numeric_over_tex"],
             "inner_numeric_over_tex": diagnosis["inner_numeric_over_tex"],

--- a/tools/diagnostics/curved_1disk_miss_diagnosis.py
+++ b/tools/diagnostics/curved_1disk_miss_diagnosis.py
@@ -93,10 +93,37 @@ def _shape_propagation_evidence(
     }
 
 
-def _energy_evidence(benchmark: dict[str, object]) -> dict[str, object]:
+def _selected_energy_control_case(
+    benchmark: dict[str, object],
+    energy_control_audit: dict[str, object] | None,
+) -> dict[str, object] | None:
+    """Return the energy/control audit case nearest the selected benchmark theta."""
+    if not energy_control_audit:
+        return None
+    cases = list(energy_control_audit.get("cases") or [])
+    if not cases:
+        return None
+    theta_selected = float(benchmark["theta_B_selected"])
+    return min(cases, key=lambda case: abs(float(case["theta_B"]) - theta_selected))
+
+
+def _energy_evidence(
+    benchmark: dict[str, object],
+    energy_control_audit: dict[str, object] | None = None,
+) -> dict[str, object]:
     """Summarize energy mismatch at the selected numeric thetaB."""
     expected = _expected_energy_at_selected_theta(benchmark)
-    energies = benchmark["energies"]
+    audit_case = _selected_energy_control_case(benchmark, energy_control_audit)
+    using_reconciled_audit = (
+        audit_case is not None
+        and abs(float(audit_case["theta_B"]) - float(benchmark["theta_B_selected"]))
+        <= 1.0e-9
+    )
+    energies = (
+        audit_case["numeric_energy_split"]
+        if using_reconciled_audit
+        else benchmark["energies"]
+    )
     ratios = {
         "inner_elastic_numeric_over_tex_at_selected_theta": _safe_ratio(
             float(energies["inner_elastic_numeric"]), expected["inner_elastic"]
@@ -110,7 +137,19 @@ def _energy_evidence(benchmark: dict[str, object]) -> dict[str, object]:
         "total_numeric_minus_tex_at_selected_theta": float(energies["total_numeric"])
         - expected["total"],
     }
+    legacy = None
+    reconciliation = None
+    attribution = None
+    if using_reconciled_audit:
+        legacy = audit_case.get("legacy_numeric_energy_split")
+        reconciliation = audit_case.get("runtime_energy_reconciliation")
+        attribution = audit_case.get("shell_attribution_coverage")
     return {
+        "source": (
+            "energy_control_runtime_reconciled"
+            if using_reconciled_audit
+            else "benchmark_legacy_split"
+        ),
         "tex_at_selected_theta": expected,
         "numeric_at_selected_theta": {
             "inner_elastic": float(energies["inner_elastic_numeric"]),
@@ -118,10 +157,24 @@ def _energy_evidence(benchmark: dict[str, object]) -> dict[str, object]:
             "contact": float(energies["contact_numeric"]),
             "total": float(energies["total_numeric"]),
         },
+        "legacy_numeric_at_selected_theta": None
+        if legacy is None
+        else {
+            "inner_elastic": float(legacy["inner_elastic_numeric"]),
+            "outer_elastic": float(legacy["outer_elastic_numeric"]),
+            "contact": float(legacy["contact_numeric"]),
+            "total": float(legacy["total_numeric"]),
+        },
+        "runtime_energy_reconciliation": reconciliation,
+        "shell_attribution_coverage": attribution,
         "ratios": ratios,
         "call": (
             "outer elastic overgrowth dominates selected-theta energy"
             if ratios["outer_elastic_numeric_over_tex_at_selected_theta"] > 5.0
+            else "legacy split mismatch was diagnostic attribution, not runtime energy"
+            if using_reconciled_audit
+            and attribution is not None
+            and abs(float(attribution.get("unattributed_fraction", 1.0))) <= 1.0e-9
             else "energy split mismatch needs deeper attribution"
         ),
     }
@@ -257,13 +310,19 @@ def _failure_explanations(
     theta_num = float(benchmark["theta_B_selected"])
     theta_theory = float(theory["theta_B_opt"])
     outer_ratio = energies["ratios"]["outer_elastic_numeric_over_tex_at_selected_theta"]
+    energy_source = str(energies.get("source") or "benchmark_legacy_split")
     return {
         "theta_B_opt": {
             "numeric": theta_num,
             "tex_target": theta_theory,
             "ratio_numeric_over_target": _safe_ratio(theta_num, theta_theory),
             "interpretation": (
-                "the local scan selects a low-theta branch because the realized "
+                "the local scan still selects a low-theta branch; after runtime "
+                "energy reconciliation the severe legacy split is gone, so the "
+                "remaining miss points back to profile propagation and moderate "
+                "elastic overgrowth"
+                if energy_source == "energy_control_runtime_reconciled"
+                else "the local scan selects a low-theta branch because the realized "
                 "outer elastic cost is far above the TeX quadratic cost"
             ),
         },
@@ -299,15 +358,24 @@ def _failure_explanations(
             ),
         },
         "energy_split": {
+            "source": energy_source,
             "outer_elastic_numeric_over_tex_at_selected_theta": outer_ratio,
             "contact_numeric_over_tex_at_selected_theta": energies["ratios"][
                 "contact_numeric_over_tex_at_selected_theta"
             ],
+            "shell_unattributed_outer_fraction": None
+            if energies.get("shell_attribution_coverage") is None
+            else float(energies["shell_attribution_coverage"]["unattributed_fraction"]),
             "theta_out_over_half_theta_B": float(
                 near_rim["theta_out_over_half_theta_B"]
             ),
             "interpretation": (
-                "contact work is consistent with the selected thetaB, but selected "
+                "Gate A reconciles the diagnostic split to runtime module totals: "
+                "contact work is consistent with the selected thetaB, shell-local "
+                "outer attribution closes, and the remaining elastic overgrowth is "
+                "moderate rather than the old severe outer/inner split"
+                if energy_source == "energy_control_runtime_reconciled"
+                else "contact work is consistent with the selected thetaB, but selected "
                 "thetaB is too small and outer elastic overgrowth dominates the split"
             ),
         },
@@ -354,9 +422,26 @@ def _rank_candidate_causes(
         else 0
     )
 
+    audit_conclusion = (
+        "The deeper audit now reconciles shell-local outer attribution to runtime "
+        "module totals; the previous large unattributed outer fraction was a "
+        "diagnostic split bug, not evidence for a runtime energy-ownership defect."
+    )
+    audit_stream = (
+        "treat energy ownership as reconciled for now and prioritize the highest "
+        "remaining audit/shape cause before changing runtime physics"
+    )
+    if isinstance(energy_control_top, dict):
+        audit_conclusion = (
+            f"The deeper audit ranks {energy_control_top.get('cause')} highest "
+            "after runtime-module reconciliation; use its evidence before any "
+            "runtime energy/sign change."
+        )
+        audit_stream = str(energy_control_top.get("recommended_stream") or audit_stream)
+
     candidates = [
         {
-            "cause": "inner/outer leaflet imbalance or outer split attribution mismatch",
+            "cause": "reconciled energy/control audit residuals",
             "rank_score": energy_control_top_score if energy_control_top_score else 35,
             "evidence": {
                 "energy_control_audit": {
@@ -364,16 +449,8 @@ def _rank_candidate_causes(
                     "root_causes_ranked": energy_control_causes,
                 },
             },
-            "conclusion": (
-                "The deeper audit finds the remaining miss is not explained by "
-                "the fixed target direction alone: inner elastic is far below "
-                "TeX, outer elastic is far above TeX, and most numeric outer "
-                "elastic is not explained by shell-local attribution."
-            ),
-            "smallest_next_fix_stream": (
-                "audit the disk/outer split helper against runtime module ownership "
-                "and leaflet sign/ownership conventions before changing physics"
-            ),
+            "conclusion": audit_conclusion,
+            "smallest_next_fix_stream": audit_stream,
         },
         {
             "cause": "curvature generation does not propagate",
@@ -481,9 +558,9 @@ def run_curved_1disk_miss_diagnosis(
         )
 
     shape = _shape_propagation_evidence(benchmark)
-    energy = _energy_evidence(benchmark)
     control = _control_volume_evidence(control_volume_rows, energy_control_audit)
     target = _target_direction_evidence(phi_target_audit, shell2_audit)
+    energy = _energy_evidence(benchmark, energy_control_audit)
     failures = _failure_explanations(
         benchmark,
         shape_evidence=shape,


### PR DESCRIPTION
## Summary
- add a Feature Contract for the curved 1-disk energy ownership/split stream
- reconcile the energy/control-volume audit split to runtime module totals
- keep the legacy split in the report as diagnostic evidence
- update aggregate diagnosis wording/ranking to stop treating the closed split residual as a runtime defect

## Motivation / Context
- PR3 showed selected thetaB remains 0.12 and the legacy diagnostic split reported outer elastic about 8.46x high with most outer energy unattributed.
- This PR tests whether that is diagnostic accounting or runtime energy ownership before any physics change.

## Design Notes
- Feature contract link/summary: docs/FEATURE_CONTRACT_CURVED_1DISK_ENERGY_OWNERSHIP.md; Gate A is diagnostic-only reconciliation, with runtime changes deferred unless a defect is proven.
- Interfaces changed (if any): diagnostic JSON gains legacy_numeric_energy_split, numeric_energy_split reconciled to runtime modules, runtime_module_totals, runtime_energy_reconciliation, and aggregate energy source/residual fields.
- Invariants enforced: reconciled inner + outer elastic equals runtime elastic total; reconciled inner + outer + contact equals runtime total; shell-attributed outer residual is zero for the selected split.

## How to Test
```bash
ruff check tools/diagnostics/curved_1disk_miss_diagnosis.py tools/diagnostics/curved_1disk_energy_control_volume_audit.py tests/test_curved_1disk_miss_diagnosis.py tests/test_curved_1disk_energy_control_volume_audit.py
pytest -q tests/test_curved_1disk_miss_diagnosis.py tests/test_curved_1disk_energy_control_volume_audit.py
pytest -q -m benchmark tests/test_curved_1disk_energy_control_volume_audit.py
python -m tools.diagnostics.curved_1disk_energy_control_volume_audit --theta 0.12
python -m tools.diagnostics.curved_1disk_energy_control_volume_audit
python -m tools.diagnostics.curved_1disk_forced_theta_diagnostic
pytest -q -m benchmark tests/test_curved_1disk_theory_benchmark.py tests/test_curved_1disk_energy_control_volume_audit.py tests/test_curved_1disk_shared_rim_fix_acceptance.py
```
- Attempted `python -m tools.diagnostics.curved_1disk_miss_diagnosis --skip-target-audits --skip-control-volume`; stopped after an extended benchmark recomputation with no output. Aggregate wiring is covered by injected-report tests.

## Risks & Mitigations
- Diagnostic consumers expecting only the legacy split may need to read the new explicit legacy field; the reconciled field keeps the existing numeric_energy_split name.
- No runtime physics, solver, constraint, or energy module behavior changes are included.

## Performance / Benchmarks (if relevant)
- Benchmark subset passed: 6 passed, 2 deselected in 537.55s.
- Selected-theta energy audit now reports outer elastic about 1.866x TeX, inner about 1.596x TeX, contact about 0.996x TeX, and zero unattributed outer residual after reconciliation.

## Assumptions / Open Questions
- The previous 78% unattributed outer energy is diagnostic accounting, not sufficient evidence for a runtime energy ownership/sign fix.
- Next stream should prioritize fixed-theta shape propagation unless later evidence reopens runtime energy ownership.