### PR TITLE
Fix curved 1-disk shape propagation blocker

### DIFF
--- a/modules/constraints/rim_slope_match_out.py
+++ b/modules/constraints/rim_slope_match_out.py
@@ -1877,6 +1877,7 @@ def enforce_constraint(mesh: Mesh, global_params=None, **_kwargs) -> None:
     closely as possible before the tilt-only projection runs.
     """
     matching_mode = _resolve_matching_mode(global_params)
+    context = str(_kwargs.get("context") or "").strip().lower()
     if matching_mode not in {
         "physical_edge_staggered_v1",
         "shared_rim_staggered_v1",
@@ -1946,6 +1947,9 @@ def enforce_constraint(mesh: Mesh, global_params=None, **_kwargs) -> None:
 
     height_num = np.zeros(len(mesh.vertex_ids), dtype=float)
     height_den = np.zeros(len(mesh.vertex_ids), dtype=float)
+    update_tilt_out = not (
+        matching_mode == "shared_rim_staggered_v1" and context == "minimize"
+    )
     tilt_num = np.zeros(len(mesh.vertex_ids), dtype=float)
     tilt_den = np.zeros(len(mesh.vertex_ids), dtype=float)
 
@@ -2021,13 +2025,15 @@ def enforce_constraint(mesh: Mesh, global_params=None, **_kwargs) -> None:
         if abs(w0) > 1.0e-12:
             height_num[row0] += w0 * target_height
             height_den[row0] += abs(w0)
-            tilt_num[row0] += w0 * t_out_target
-            tilt_den[row0] += abs(w0)
+            if update_tilt_out:
+                tilt_num[row0] += w0 * t_out_target
+                tilt_den[row0] += abs(w0)
         if abs(w1) > 1.0e-12:
             height_num[row1] += w1 * target_height
             height_den[row1] += abs(w1)
-            tilt_num[row1] += w1 * t_out_target
-            tilt_den[row1] += abs(w1)
+            if update_tilt_out:
+                tilt_num[row1] += w1 * t_out_target
+                tilt_den[row1] += abs(w1)
 
     moved = False
     for row in np.flatnonzero(height_den > 1.0e-12):
@@ -2065,7 +2071,8 @@ def enforce_constraint(mesh: Mesh, global_params=None, **_kwargs) -> None:
 
     if moved:
         mesh.increment_version()
-    mesh.touch_tilts_out()
+    if update_tilt_out:
+        mesh.touch_tilts_out()
 
 
 __all__ = [

--- a/runtime/minimizer.py
+++ b/runtime/minimizer.py
@@ -2566,6 +2566,19 @@ STEP SIZE:\t {self.step_size}
             if getattr(self.mesh.vertices[int(vidx)], "fixed", False):
                 grad_arr[row] = 0.0
 
+    def _project_curved_free_disk_shape_dofs(self, grad_arr: np.ndarray) -> None:
+        """Restrict the shared-rim curved free-disk shape solve to height DOFs."""
+        mode = str(self.global_params.get("rim_slope_match_mode") or "").strip().lower()
+        if mode != "shared_rim_staggered_v1":
+            return
+        if not (
+            self.global_params.get("rim_slope_match_group") is not None
+            and self.global_params.get("rim_slope_match_outer_group") is not None
+            and self.global_params.get("rim_slope_match_disk_group") is not None
+        ):
+            return
+        grad_arr[:, :2] = 0.0
+
     def _enforce_constraints(self, mesh: Mesh | None = None):
         """Invoke all constraint modules on the current mesh."""
         if not self._has_enforceable_constraints:
@@ -2958,6 +2971,7 @@ STEP SIZE:\t {self.step_size}
             # Use array-based path for main loop
             E, grad_arr = self.compute_energy_and_gradient_array()
             self.project_constraints_array(grad_arr)
+            self._project_curved_free_disk_shape_dofs(grad_arr)
             last_grad_arr = grad_arr
 
             if logger.isEnabledFor(logging.DEBUG):

--- a/tests/test_curved_1disk_shape_propagation_blocker.py
+++ b/tests/test_curved_1disk_shape_propagation_blocker.py
@@ -1,0 +1,56 @@
+import numpy as np
+import pytest
+
+from geometry.geom_io import parse_geometry
+from modules.constraints import rim_slope_match_out
+from tests.test_rim_slope_match_out_constraint import (
+    _build_rim_match_geometry,
+    _collect_group_rows,
+)
+from tools.diagnostics.curved_1disk_shape_propagation_blocker import (
+    run_curved_1disk_shape_propagation_blocker,
+)
+
+
+def test_shared_rim_minimize_shape_enforcement_does_not_mutate_tilt_out() -> None:
+    data = _build_rim_match_geometry(z_bump=0.12)
+    data["global_parameters"]["rim_slope_match_mode"] = "shared_rim_staggered_v1"
+    data["global_parameters"]["rim_slope_match_thetaB_param"] = "tilt_thetaB_value"
+    data["global_parameters"]["tilt_thetaB_value"] = 0.2
+    mesh = parse_geometry(data)
+    mesh.build_position_cache()
+
+    outer_rows = _collect_group_rows(mesh, "outer")
+    tilts_out = mesh.tilts_out_view().copy(order="F")
+    positions = mesh.positions_view()
+    r_hat = positions[outer_rows].copy()
+    r_hat[:, 2] = 0.0
+    r_hat /= np.linalg.norm(r_hat, axis=1)[:, None]
+    tilts_out[outer_rows] = 0.03 * r_hat
+    mesh.set_tilts_out_from_array(tilts_out)
+    before = mesh.tilts_out_view().copy(order="F")
+
+    rim_slope_match_out.enforce_constraint(
+        mesh,
+        global_params=mesh.global_parameters,
+        context="minimize",
+    )
+
+    np.testing.assert_allclose(mesh.tilts_out_view(), before, atol=0.0)
+
+
+@pytest.mark.benchmark
+@pytest.mark.slow
+def test_fixed_theta_shape_blocker_report_identifies_backtracking_budget() -> None:
+    report = run_curved_1disk_shape_propagation_blocker()
+
+    assert report["classification"] == "shape_update_accepted"
+    alpha0 = report["line_search_probe"]["alpha0_enforcement"]
+    assert float(alpha0["energy_delta"]) <= 0.0
+    assert float(alpha0["tilt_out_delta_max"]) < 1.0e-3
+    trials = report["line_search_probe"]["trial_alphas"]
+    assert any(bool(row["accepted_by_decrease"]) for row in trials)
+    assert bool(report["one_step_default_backtracking"]["step_success"]) is True
+    assert bool(report["one_step_extended_backtracking"]["step_success"]) is True
+    assert float(report["one_step_extended_backtracking"]["xy_delta_abs_sum"]) < 1.0e-12
+    assert float(report["one_step_extended_backtracking"]["z_delta_abs_sum"]) > 0.0

--- a/tests/test_curved_1disk_theory_benchmark.py
+++ b/tests/test_curved_1disk_theory_benchmark.py
@@ -67,7 +67,7 @@ def test_curved_1disk_theory_benchmark_reports_current_tensionless_miss() -> Non
     assert height_fit["window"] == [3.0, 10.0]
 
     curvature = report["outer_curvature"]
-    assert float(curvature["mean_abs_J"]) > 0.05
+    assert 0.01 < float(curvature["mean_abs_J"]) < 0.05
     assert float(curvature["p95_abs_J"]) > 0.15
 
     energies = report["energies"]

--- a/tools/diagnostics/curved_1disk_shape_propagation_blocker.py
+++ b/tools/diagnostics/curved_1disk_shape_propagation_blocker.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Diagnose fixed-theta curved 1-disk shape propagation blockers.
+
+This report uses theory theta only as a fixed external drive.  It classifies
+whether the current lane has a shape force, whether projection removes it,
+whether constraint enforcement mutates unrelated DOFs during line search, and
+whether the line-search budget reaches an accepted physical descent step.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+
+import numpy as np
+
+from runtime.constraint_manager import ConstraintModuleManager
+from runtime.energy_manager import EnergyModuleManager
+from runtime.minimizer import Minimizer
+from runtime.steppers.gradient_descent import GradientDescent
+from tools.diagnostics.curved_1disk_shared_rim_phi_target_audit import THEORY_THETA_B
+from tools.diagnostics.curved_1disk_theory_benchmark import (
+    _refine_once,
+    load_free_disk_curved_bilayer_mesh,
+)
+from tools.diagnostics.free_disk_profile_protocol import (
+    configure_free_disk_curved_bilayer_stage2,
+)
+
+DEFAULT_ALPHAS = (1.0e-3, 1.0e-4, 1.0e-5, 1.0e-6, 1.0e-7)
+
+
+def _build_minimizer(theta_b: float, *, max_iter: int) -> Minimizer:
+    """Return a configured fixed-theta curved free-disk minimizer."""
+    mesh = _refine_once(load_free_disk_curved_bilayer_mesh())
+    configure_free_disk_curved_bilayer_stage2(mesh, theta_b=float(theta_b), z_bump=None)
+    gp = mesh.global_parameters
+    gp.set("tilt_solve_mode", "coupled")
+    gp.set("tilt_solver", "gd")
+    gp.set("tilt_step_size", 0.15)
+    gp.set("tilt_inner_steps", 10)
+    gp.set("tilt_tol", 1.0e-8)
+    gp.set("tilt_kkt_projection_during_relaxation", False)
+    gp.set("tilt_thetaB_optimize", False)
+    gp.set("tilt_thetaB_value", float(theta_b))
+    gp.set("step_size_mode", "fixed")
+    gp.set("step_size", 1.0e-3)
+    return Minimizer(
+        mesh,
+        gp,
+        GradientDescent(max_iter=int(max_iter)),
+        EnergyModuleManager(mesh.energy_modules),
+        ConstraintModuleManager(mesh.constraint_modules),
+        quiet=True,
+        tol=1.0e-6,
+    )
+
+
+def _shell_stats(mesh, values: np.ndarray) -> list[dict[str, float | int]]:
+    """Aggregate a per-row scalar by radial shell."""
+    positions = mesh.positions_view()
+    radii = np.linalg.norm(positions[:, :2], axis=1)
+    keys = np.round(radii, decimals=8)
+    rows: list[dict[str, float | int]] = []
+    for key in sorted(set(float(k) for k in keys)):
+        mask = np.isclose(keys, key, atol=5.0e-9)
+        vals = np.asarray(values[mask], dtype=float)
+        rows.append(
+            {
+                "radius": float(np.median(radii[mask])),
+                "row_count": int(vals.size),
+                "abs_sum": float(np.sum(np.abs(vals))),
+                "max_abs": float(np.max(np.abs(vals))) if vals.size else 0.0,
+                "median": float(np.median(vals)) if vals.size else 0.0,
+            }
+        )
+    return rows
+
+
+def _restore_state(mesh, positions, tilts, tilts_in, tilts_out) -> None:
+    for row, vid in enumerate(mesh.vertex_ids):
+        mesh.vertices[int(vid)].position[:] = positions[row]
+    mesh.set_tilts_from_array(tilts)
+    mesh.set_tilts_in_from_array(tilts_in)
+    mesh.set_tilts_out_from_array(tilts_out)
+    mesh.increment_version()
+    mesh.build_position_cache()
+
+
+def _line_search_probe(minim: Minimizer, alphas: Sequence[float]) -> dict[str, object]:
+    """Return trial-energy deltas along the projected shape descent direction."""
+    mesh = minim.mesh
+    minim.enforce_constraints_after_mesh_ops(mesh)
+    minim._relax_leaflet_tilts(
+        positions=mesh.positions_view(),
+        mode=mesh.global_parameters.get("tilt_solve_mode", "fixed"),
+    )
+    energy, grad = minim.compute_energy_and_gradient_array()
+    raw_grad = np.array(grad, copy=True)
+    minim.project_constraints_array(grad)
+    minim._project_curved_free_disk_shape_dofs(grad)
+    projected_grad = np.array(grad, copy=True)
+
+    positions0 = mesh.positions_view().copy(order="F")
+    tilts0 = mesh.tilts_view().copy(order="F")
+    tilts_in0 = mesh.tilts_in_view().copy(order="F")
+    tilts_out0 = mesh.tilts_out_view().copy(order="F")
+    baseline = float(minim._line_search_energy_fn()())
+
+    minim._enforce_constraints()
+    alpha0_energy = float(minim._line_search_energy_fn()())
+    alpha0_pos_delta = float(np.linalg.norm(mesh.positions_view() - positions0))
+    alpha0_tilt_out_delta = float(
+        np.max(np.linalg.norm(mesh.tilts_out_view() - tilts_out0, axis=1))
+    )
+    _restore_state(mesh, positions0, tilts0, tilts_in0, tilts_out0)
+
+    direction = -projected_grad
+    movable = ~mesh.fixed_mask
+    trials: list[dict[str, float | bool]] = []
+    for alpha in alphas:
+        trial_positions = positions0.copy(order="F")
+        trial_positions[movable] = (
+            trial_positions[movable] + float(alpha) * direction[movable]
+        )
+        for row, vid in enumerate(mesh.vertex_ids):
+            mesh.vertices[int(vid)].position[:] = trial_positions[row]
+        mesh.increment_version()
+        mesh.build_position_cache()
+        no_enforce = float(minim.compute_energy())
+        minim._enforce_constraints()
+        enforced = float(minim._line_search_energy_fn()())
+        trials.append(
+            {
+                "alpha": float(alpha),
+                "energy_delta_no_enforce": float(no_enforce - baseline),
+                "energy_delta_after_enforce": float(enforced - baseline),
+                "accepted_by_decrease": bool(enforced <= baseline),
+            }
+        )
+        _restore_state(mesh, positions0, tilts0, tilts_in0, tilts_out0)
+
+    raw_z = raw_grad[:, 2]
+    proj_z = projected_grad[:, 2]
+    return {
+        "baseline_energy": baseline,
+        "gradient_energy": float(energy),
+        "raw_gradient_norm": float(np.linalg.norm(raw_grad)),
+        "projected_gradient_norm": float(np.linalg.norm(projected_grad)),
+        "projection_norm_loss": float(np.linalg.norm(raw_grad - projected_grad)),
+        "raw_z_by_shell": _shell_stats(mesh, raw_z),
+        "projected_z_by_shell": _shell_stats(mesh, proj_z),
+        "alpha0_enforcement": {
+            "energy_delta": float(alpha0_energy - baseline),
+            "position_delta_norm": alpha0_pos_delta,
+            "tilt_out_delta_max": alpha0_tilt_out_delta,
+        },
+        "trial_alphas": trials,
+    }
+
+
+def _one_step_probe(theta_b: float, *, max_iter: int) -> dict[str, object]:
+    """Run one minimizer step and return accepted shell-wise z updates."""
+    minim = _build_minimizer(theta_b, max_iter=max_iter)
+    mesh = minim.mesh
+    minim.enforce_constraints_after_mesh_ops(mesh)
+    before = mesh.positions_view().copy(order="F")
+    before_energy = float(minim.compute_energy())
+    result = minim.minimize(n_steps=1)
+    after = mesh.positions_view().copy(order="F")
+    dz = after[:, 2] - before[:, 2]
+    dxy = np.linalg.norm(after[:, :2] - before[:, :2], axis=1)
+    return {
+        "max_iter": int(max_iter),
+        "step_success": bool(result["step_success"]),
+        "energy_delta": float(float(result["energy"]) - before_energy),
+        "position_delta_norm": float(np.linalg.norm(after - before)),
+        "xy_delta_abs_sum": float(np.sum(np.abs(dxy))),
+        "z_delta_abs_sum": float(np.sum(np.abs(dz))),
+        "z_delta_by_shell": _shell_stats(mesh, dz),
+    }
+
+
+def _classify(line_probe: dict[str, object], default_step: dict[str, object]) -> str:
+    """Return a compact blocker classification."""
+    alpha0 = line_probe["alpha0_enforcement"]
+    if float(alpha0["energy_delta"]) > 1.0e-8:
+        return "constraint_enforcement_mutates_tilt_line_search_baseline"
+    trials = list(line_probe["trial_alphas"])
+    if not any(bool(row["accepted_by_decrease"]) for row in trials):
+        return "no_descent_alpha_found"
+    if not bool(default_step["step_success"]):
+        return "line_search_backtracking_budget_too_shallow"
+    return "shape_update_accepted"
+
+
+def run_curved_1disk_shape_propagation_blocker(
+    *,
+    theta_b: float = THEORY_THETA_B,
+) -> dict[str, object]:
+    """Return the fixed-theta shape propagation blocker report."""
+    line_minim = _build_minimizer(theta_b, max_iter=10)
+    line_probe = _line_search_probe(line_minim, DEFAULT_ALPHAS)
+    default_step = _one_step_probe(theta_b, max_iter=10)
+    extended_step = _one_step_probe(theta_b, max_iter=20)
+    return {
+        "theta_B": float(theta_b),
+        "classification": _classify(line_probe, default_step),
+        "line_search_probe": line_probe,
+        "one_step_default_backtracking": default_step,
+        "one_step_extended_backtracking": extended_step,
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--theta", type=float, default=THEORY_THETA_B)
+    args = parser.parse_args(argv)
+    report = run_curved_1disk_shape_propagation_blocker(theta_b=float(args.theta))
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds a fixed-theta shape propagation blocker diagnostic for the curved 1-disk free-membrane lane.
- Stops `rim_slope_match_out` shape enforcement from mutating `tilt_out` during minimizer line search for `shared_rim_staggered_v1`.
- Restricts the shared-rim curved free-disk shape step to height (`z`) DOFs so accepted motion does not spend descent on in-plane mesh drift.
- Updates the known-miss theory benchmark diagnostic to reflect the reduced mean outer curvature after removing in-plane drift.

## Motivation / Context
- PR505 left the fixed-theta lane with weak outer shape propagation. The blocker diagnostic shows the shape gradient is present and survives projection, but previous enforcement/shape-step behavior could prevent clean physical height relaxation.
- This PR fixes the numerical blocker without tuning against `docs/1_disk_3d.tex`; the TeX profile checks remain external validation and still xfail where the far-field log/K1 profile is not reproduced.

## Design Notes
- Feature contract link/summary: `docs/FEATURE_CONTRACT_CURVED_1DISK_SHAPE_PROPAGATION.md` covers the approved shape propagation stream.
- Interfaces changed (if any): no public config or CLI changes. Adds diagnostic module `tools.diagnostics.curved_1disk_shape_propagation_blocker`.
- Invariants enforced: shell-2 target direction remains outward; near-rim split is preserved; accepted fixed-theta shape updates have nonzero `z` motion and effectively zero `xy` drift.

## How to Test
```bash
ruff check runtime/minimizer.py modules/constraints/rim_slope_match_out.py tools/diagnostics/curved_1disk_shape_propagation_blocker.py tests/test_curved_1disk_shape_propagation_blocker.py tests/test_curved_1disk_theory_benchmark.py
pytest -q tests/test_curved_1disk_shape_propagation_blocker.py tests/test_step_size_mode.py tests/test_minimizer_array_only.py -o addopts=''
pytest -q -o addopts='' tests/test_curved_1disk_shared_rim_fix_acceptance.py
pytest -q -m benchmark tests/test_curved_1disk_theory_benchmark.py::test_curved_1disk_theory_benchmark_reports_current_tensionless_miss -o addopts=''
python -m tools.diagnostics.curved_1disk_shape_propagation_blocker
python -m tools.diagnostics.curved_1disk_forced_theta_diagnostic
python -m tools.diagnostics.curved_1disk_miss_diagnosis --skip-target-audits --skip-control-volume
python -m tools.diagnostics.curved_1disk_energy_control_volume_audit --theta 0.12 --theta 0.1845693593
python -m tools.diagnostics.curved_1disk_shared_rim_phi_target_audit
python -m tools.diagnostics.curved_1disk_shell2_tiltout_audit
```
- Full `pytest -q` was deferred because this PR is scoped to the curved free-disk lane and the benchmark subset is already slow.

## Risks & Mitigations
- Risk: `runtime/minimizer.py` is shared code. Mitigation: the height-DOF projection is gated to `rim_slope_match_mode='shared_rim_staggered_v1'` with shared-rim group parameters present.
- Risk: direct constraint projection behavior could regress. Mitigation: existing `rim_slope_match_out` tests pass; the minimize context is the only path that skips tilt mutation in `enforce_constraint`.
- Risk: this may be mistaken for full theory reproduction. Mitigation: the log/K1 profile tests remain xfailed and diagnostics still report the far-field miss.

## Performance / Benchmarks (if relevant)
- Targeted benchmark subset run: shared-rim fix acceptance passed with `4 passed, 2 xfailed`.
- Known-miss theory benchmark remains a diagnostic and passes with updated curvature evidence.

## Assumptions / Open Questions
- Assumption: for this curved free-disk lane, the physical shape DOF is a height graph over fixed radial coordinates, so in-plane mesh drift is a parametrization artifact.
- Open follow-up: far-field log/K1 propagation is still weak; forced-theta diagnostics point to a remaining outer shape/energy propagation problem rather than a `thetaB` tuning issue.
