### PR TITLE
Diagnose curved 1-disk outer profile propagation

### DIFF
--- a/docs/FEATURE_CONTRACT_CURVED_1DISK_SUPPORT_GRADIENT_FIX.md
+++ b/docs/FEATURE_CONTRACT_CURVED_1DISK_SUPPORT_GRADIENT_FIX.md
@@ -1,0 +1,89 @@
+# Feature Contract: Curved 1-Disk Support-Gradient Fix
+
+## Goal
+Fix the curved free-disk shape solve so accepted fixed-theta shape updates are
+not dominated by shared-rim support-shell `z` gradients when a valid outer
+trumpet descent direction exists.
+
+## Non-goals
+- Do not rescale energies, add calibration factors, hidden weights, or tune
+  coefficients to `docs/1_disk_3d.tex`.
+- Do not change theta scan scheduling, contact strength, or public config by
+  default.
+- Do not change shell-2 target direction, near-rim split semantics, or energy
+  ownership unless a new diagnostic proves those regressed.
+- Do not claim full theory reproduction until fixed-theta profile fits and
+  selected-theta behavior are both validated.
+
+## User-visible behavior
+- At fixed `thetaB ~= 0.1845693593`, accepted shape updates should retain a
+  meaningful component along the outer log/trumpet direction instead of being
+  almost entirely near-support-shell motion.
+- The outer height log profile should move in the physical trumpet direction
+  over short fixed-theta relaxations.
+- Existing shared-rim invariants remain preserved: outward shell-2 target,
+  near-rim half split, `z`-only curved free-disk shape updates, and Gate A
+  energy reconciliation.
+
+## Public interfaces to add/change
+- No public CLI/config/API changes by default.
+- Diagnostic-only helpers may expose support-gradient, shell-normalized, or
+  area-weighted direction metrics.
+- Runtime changes, if needed, must be internal to the curved free-disk lane and
+  must not introduce new user-facing tuning knobs.
+
+## Data model / file format changes
+- None.
+
+## Key invariants
+- Runtime module totals must reconcile with diagnostic energy deltas before and
+  after the fix.
+- Constraint enforcement must not reset free outer `z` perturbations or mutate
+  unrelated tilt fields during minimize line search.
+- Any metric/preconditioner or support-shell handling must be derived from
+  geometry/control-volume structure, not from matching theory coefficients.
+- Existing non-curved and non-`shared_rim_staggered_v1` lanes must remain
+  behaviorally unchanged.
+
+## Failure modes & error handling
+- If support-shell suppression improves alignment but breaks near-rim split or
+  target direction, stop and keep the failing test as evidence.
+- If area/shell-normalized probes improve alignment only diagnostically but do
+  not improve accepted runtime updates, do not claim a fix; classify the
+  blocker as solver/path conditioning.
+- If fixed-theta profile improves while energy reconciliation regresses, revert
+  the runtime change and restore the reconciliation invariant.
+
+## Rejected candidates
+- Hard-freezing the support-transition one-ring removes the immediate support
+  dominance and gives the fixed-theta log slope the physical sign, but it
+  regresses selected `thetaB` to `0.06`; keep the acceptance checks as xfailed
+  evidence, not as a runtime fix.
+- Uniformly damping the transition-band gradient preserves selected `thetaB`
+  only when the damping is weak enough that support-shell domination and the
+  negative short-relaxation log slope remain.
+- Re-projecting after the curved lane's `z`-only shape projection preserves the
+  selected-theta ordering but does not change the support-dominated accepted
+  update. A z-only KKT variant increases support alignment.
+
+## Test plan
+- Add acceptance-first tests that currently fail or remain xfailed for:
+  - accepted update alignment: log/trumpet component increases relative to the
+    current `~0.03` one-step cosine;
+  - near-support domination decreases from the current `~0.58` one-step cosine;
+  - fixed-theta outer log slope gets the physical sign over short relaxation;
+  - shared-rim target direction, near-rim half split, and `z`-only shape updates
+    do not regress.
+- Run diagnostics:
+  - `python -m tools.diagnostics.curved_1disk_trumpet_descent_audit`
+  - `python -m tools.diagnostics.curved_1disk_shape_direction_audit`
+  - `python -m tools.diagnostics.curved_1disk_shape_propagation_blocker`
+  - `python -m tools.diagnostics.curved_1disk_energy_control_volume_audit --theta 0.1845693593`
+- Run focused tests:
+  - `pytest -q tests/test_curved_1disk_trumpet_descent_audit.py tests/test_curved_1disk_shape_direction_audit.py`
+  - `pytest -q -o addopts='' tests/test_curved_1disk_shared_rim_fix_acceptance.py`
+
+## Performance considerations
+- Any runtime fix that changes shape metric, preconditioning, projection, or
+  support-shell ownership affects numerical behavior and must include the
+  representative curved 1-disk benchmark diagnostics above.

--- a/docs/FEATURE_CONTRACT_CURVED_1DISK_TRANSITION_BAND_OWNERSHIP_FIX.md
+++ b/docs/FEATURE_CONTRACT_CURVED_1DISK_TRANSITION_BAND_OWNERSHIP_FIX.md
@@ -1,0 +1,88 @@
+# Feature Contract: Curved 1-Disk Transition-Band Ownership Fix
+
+## Goal
+Correct the curved free-disk shared-rim transition band so artificial interface
+support rows/triangles no longer carry nearly all outer-membrane elastic energy
+and shape-gradient ownership.
+
+## Non-goals
+- Do not rescale energies, tune coefficients, add calibration factors, or add
+  hidden weights to force agreement with `docs/1_disk_3d.tex`.
+- Do not change theta scan scheduling, contact strength, shell-2 target
+  direction, or public config by default.
+- Do not remove the shared-rim support ring or hard-freeze its shape gradient;
+  that candidate already regressed selected `thetaB` to `0.06`.
+- Do not claim full theory reproduction until fixed-theta profile fits and
+  selected-theta behavior both pass.
+
+## User-visible behavior
+- At fixed `thetaB ~= 0.1845693593`, short curved free-disk relaxation should
+  move the outer log-height slope in the physical trumpet direction.
+- Transition-band attributed outer elastic fraction should fall from the current
+  diagnostic value of `~0.983` because the artificial support band should not
+  represent almost the entire outer membrane.
+- Transition-band projected shape-gradient fraction should fall from the current
+  diagnostic value of `~0.9996`.
+- Selected `thetaB` must not regress to the low `0.06` branch; movement in
+  selected theta must follow from corrected ownership, not a tuning rule.
+- Existing near-rim half split, outward shell-2 target direction, and `z`-only
+  curved free-disk shape update invariants remain preserved.
+
+## Public interfaces to add/change
+- No public CLI/config/API changes by default.
+- Diagnostic reports may add transition-band ownership fields if needed.
+- Runtime changes must be internal to the curved free-disk
+  `shared_rim_staggered_v1` lane.
+
+## Data model / file format changes
+- None.
+
+## Key invariants
+- Runtime module totals must continue to reconcile with diagnostic energy
+  breakdowns.
+- Shape-gradient module sums must reconcile with the full projected gradient.
+- Artificial support-band handling must be geometry/control-volume derived, not
+  chosen from theory-fit coefficients.
+- Non-curved and non-`shared_rim_staggered_v1` lanes must remain behaviorally
+  unchanged.
+
+## Failure modes & error handling
+- If a candidate improves fixed-theta log slope but selected `thetaB` returns to
+  `0.06`, reject it and keep the failing acceptance test as evidence.
+- If energy reconciliation regresses, revert the runtime change before further
+  tuning.
+- If transition-band ownership remains dominant after the change, do not claim a
+  fix; continue with a narrower module-level ownership audit.
+
+## Rejected candidates
+- Redistributing artificial support-row corner area to the non-support corners
+  keeps the transition triangles physically active, but preserves too much of
+  the oversized transition control volume. In the fixed-theta sweep it makes the
+  elastic response too stiff and pushes candidate ordering back toward the low
+  branch. A later control-volume fix must use a geometry-derived radial
+  ownership width, not a fitted area fraction.
+- Scaling support-transition triangle control areas by their radial overlap with
+  the physical outer sliver is also too stiff. The scaled area is small, but the
+  transition gradients remain singularly large, so this is not just an area
+  accounting problem.
+
+## Test plan
+- Acceptance-first tests:
+  - transition-band outer elastic fraction drops below the current `~0.983`;
+  - transition-band projected gradient fraction drops below the current
+    `~0.9996`;
+  - fixed-theta one-step/short-relaxation outer log slope gets the physical sign;
+  - selected `thetaB` stays above `0.06`;
+  - shared-rim target direction, near-rim split, and `z`-only update invariants
+    remain green.
+- Diagnostics:
+  - `python -m tools.diagnostics.curved_1disk_transition_band_ownership_audit`
+  - `python -m tools.diagnostics.curved_1disk_shape_direction_audit`
+  - `python -m tools.diagnostics.curved_1disk_energy_control_volume_audit --theta 0.1845693593`
+- Focused tests:
+  - `pytest -q tests/test_curved_1disk_transition_band_ownership_audit.py tests/test_curved_1disk_support_gradient_fix_acceptance.py`
+  - `pytest -q -o addopts='' tests/test_curved_1disk_shared_rim_fix_acceptance.py`
+
+## Performance considerations
+- Any energy/gradient ownership change affects hot numerical paths and must be
+  validated with the representative curved 1-disk benchmark diagnostics above.

--- a/docs/FEATURE_CONTRACT_CURVED_1DISK_TRANSITION_GRADIENT_REGULARITY_FIX.md
+++ b/docs/FEATURE_CONTRACT_CURVED_1DISK_TRANSITION_GRADIENT_REGULARITY_FIX.md
@@ -1,0 +1,91 @@
+# Feature Contract: Curved 1-Disk Transition-Gradient Regularity Fix
+
+## Goal
+Replace the remaining singular shared-rim support-transition derivative path
+with a geometry-derived discretization that preserves fixed-theta shape
+propagation without making the theta sweep too soft or too stiff.
+
+## Non-goals
+- Do not rescale energies, tune coefficients, add hidden weights, or fit to
+  `docs/1_disk_3d.tex`.
+- Do not change theta scan scheduling, contact strength, shell-2 target
+  direction, or public config by default.
+- Do not remove the support-transition one-ring shape metric fix unless a
+  diagnostic proves it is no longer needed.
+- Do not claim full theory reproduction until selected theta, log/K1 profiles,
+  and energy split all pass independently.
+
+## User-visible behavior
+- Fixed-theta short relaxation keeps the physical positive outer log-height
+  slope.
+- Selected `thetaB` does not regress to `0.06` and does not run away to the
+  current high branch near `0.22-0.26`.
+- Near-rim half split, outward shell-2 target direction, and `z`-only shape
+  updates remain preserved.
+- Runtime energy and diagnostic split totals continue to reconcile.
+
+## Public interfaces to add/change
+- No public CLI/config/API changes by default.
+- Runtime changes must stay internal to the curved free-disk
+  `shared_rim_staggered_v1` lane.
+- Diagnostic reports may add transition derivative regularity fields.
+
+## Data model / file format changes
+- None.
+
+## Key invariants
+- Any transition derivative ownership must be geometry/control-volume derived,
+  not selected from theory agreement.
+- Artificial support rows must not dominate accepted shape updates.
+- Transition energy handling must not create a low-theta or high-theta branch by
+  deleting or over-preserving a singular local derivative.
+- Non-curved and non-`shared_rim_staggered_v1` lanes remain behaviorally
+  unchanged.
+
+## Failure modes & error handling
+- If a candidate makes fixed-theta shape propagation positive but shifts
+  selected theta to the high edge, reject it as too soft.
+- If a candidate restores transition triangle energy but returns selected theta
+  to the low branch, reject it as too stiff.
+- If diagnostic energy reconciliation regresses, revert before testing profile
+  fits.
+
+## Rejected candidates
+- Full transition-triangle exclusion removes the low branch and fixes the
+  support-gradient direction, but makes the reduced energy too soft and selects
+  the current high branch.
+- Support-row-only and rim/support-row-only shape metric projections leave the
+  accepted update support-dominated and give the wrong log-slope sign.
+- Support-row corner redistribution and radial-overlap area scaling are both
+  too stiff; the transition derivative remains too large even when geometric
+  area is small.
+- One-leaflet transition exclusion splits are not sufficient: excluding only the
+  outer or only the inner leaflet prevents the high branch, but leaves the
+  system too stiff and pushes candidate ordering back toward the low branch.
+- Keeping only physical outer-edge transition triangles for the outer leaflet
+  while excluding all artificial support-transition triangles for the inner
+  leaflet is the first non-fitted candidate that avoids both the low branch and
+  the high branch in focused theta ordering. It does not remove scalar
+  transition-energy concentration, so validation must focus on gradient
+  regularity and reduced-energy ordering rather than claiming scalar support
+  energy is gone.
+
+## Test plan
+- Acceptance-first tests:
+  - selected theta stays between the previous low branch and current high branch
+    without targeting the TeX optimum directly;
+  - fixed-theta one-step log slope remains positive;
+  - transition-band projected gradient no longer dominates accepted updates;
+  - runtime module totals reconcile with diagnostic splits.
+- Diagnostics:
+  - `python -m tools.diagnostics.curved_1disk_shape_direction_audit --horizon 1`
+  - `python -m tools.diagnostics.curved_1disk_transition_band_ownership_audit`
+  - `python -m tools.diagnostics.curved_1disk_energy_control_volume_audit --theta 0.1845693593`
+  - `python -m tools.diagnostics.curved_1disk_theory_benchmark`
+- Focused tests:
+  - `pytest -q tests/test_curved_1disk_support_gradient_fix_acceptance.py tests/test_curved_1disk_transition_band_ownership_audit.py`
+  - `pytest -q -m benchmark tests/test_curved_1disk_theory_benchmark.py tests/test_curved_1disk_energy_control_volume_audit.py`
+
+## Performance considerations
+- This affects hot energy/gradient assembly and minimizer direction selection;
+  run the representative curved 1-disk benchmark diagnostics before review.

--- a/modules/energy/bending_tilt_leaflet.py
+++ b/modules/energy/bending_tilt_leaflet.py
@@ -1292,6 +1292,47 @@ def _per_vertex_params_leaflet(
     return kappa, c0
 
 
+def _shared_rim_support_transition_triangle_mask(
+    mesh: Mesh,
+    global_params,
+    tri_rows: np.ndarray,
+    *,
+    keep_physical_outer_edge: bool = False,
+) -> np.ndarray | None:
+    """Mask triangles incident to the artificial shared-rim support row."""
+    if global_params is None:
+        return None
+    mode = str(global_params.get("rim_slope_match_mode") or "").strip()
+    if mode != "shared_rim_staggered_v1":
+        return None
+
+    support_group = str(global_params.get("rim_slope_match_outer_group") or "").strip()
+    rim_group = str(global_params.get("rim_slope_match_group") or "").strip()
+    disk_group = str(global_params.get("rim_slope_match_disk_group") or "").strip()
+    if not support_group or not rim_group or not disk_group:
+        return None
+
+    support_rows = np.zeros(len(mesh.vertex_ids), dtype=bool)
+    true_free_rows = np.ones(len(mesh.vertex_ids), dtype=bool)
+    excluded_groups = {support_group, rim_group, disk_group}
+    for row, vertex_id in enumerate(mesh.vertex_ids):
+        vertex = mesh.vertices[int(vertex_id)]
+        group = vertex.options.get("rim_slope_match_group")
+        if group == support_group:
+            support_rows[row] = True
+        if group in excluded_groups:
+            true_free_rows[row] = False
+
+    if not np.any(support_rows):
+        return None
+    has_support = np.any(support_rows[tri_rows], axis=1)
+    if not keep_physical_outer_edge:
+        return has_support
+    free_corner_count = np.sum(true_free_rows[tri_rows], axis=1)
+    has_physical_outer_edge = has_support & (free_corner_count >= 2)
+    return has_support & ~has_physical_outer_edge
+
+
 def _leaflet_triangle_payload(
     mesh: Mesh,
     global_params,
@@ -1317,6 +1358,18 @@ def _leaflet_triangle_payload(
         int(mesh._vertex_ids_version),
         id(positions),
         absent_key,
+        str(global_params.get("rim_slope_match_mode") or "")
+        if global_params is not None
+        else "",
+        str(global_params.get("rim_slope_match_outer_group") or "")
+        if global_params is not None
+        else "",
+        str(global_params.get("rim_slope_match_group") or "")
+        if global_params is not None
+        else "",
+        str(global_params.get("rim_slope_match_disk_group") or "")
+        if global_params is not None
+        else "",
     )
     if use_cache:
         cached = getattr(mesh, cache_attr, None)
@@ -1359,6 +1412,21 @@ def _leaflet_triangle_payload(
         if tri_keep.size:
             tri_rows = tri_rows_full[tri_keep]
             weights = weights_full[tri_keep]
+
+    transition_mask = _shared_rim_support_transition_triangle_mask(
+        mesh,
+        global_params,
+        tri_rows_full,
+        keep_physical_outer_edge=str(cache_tag) == "out",
+    )
+    if transition_mask is not None:
+        keep_non_transition = ~transition_mask
+        if tri_keep.size:
+            tri_keep = tri_keep & keep_non_transition
+        else:
+            tri_keep = keep_non_transition
+        tri_rows = tri_rows_full[tri_keep]
+        weights = weights_full[tri_keep]
 
     g0_use = None
     g1_use = None

--- a/runtime/minimizer.py
+++ b/runtime/minimizer.py
@@ -2578,6 +2578,36 @@ STEP SIZE:\t {self.step_size}
         ):
             return
         grad_arr[:, :2] = 0.0
+        self._project_curved_free_disk_transition_shape_metric(grad_arr)
+
+    def _project_curved_free_disk_transition_shape_metric(
+        self, grad_arr: np.ndarray
+    ) -> None:
+        """Remove artificial shared-rim support-transition rows from shape descent."""
+        support_group = str(
+            self.global_params.get("rim_slope_match_outer_group") or ""
+        ).strip()
+        if not support_group:
+            return
+
+        support_rows = np.zeros(len(self.mesh.vertex_ids), dtype=bool)
+        for row, vertex_id in enumerate(self.mesh.vertex_ids):
+            vertex = self.mesh.vertices[int(vertex_id)]
+            if vertex.options.get("rim_slope_match_group") == support_group:
+                support_rows[row] = True
+        if not np.any(support_rows):
+            return
+
+        tri_rows, _ = self.mesh.triangle_row_cache()
+        if tri_rows is None or len(tri_rows) == 0:
+            return
+
+        transition_rows = np.zeros(len(self.mesh.vertex_ids), dtype=bool)
+        transition_tris = np.any(support_rows[np.asarray(tri_rows, dtype=int)], axis=1)
+        transition_rows[np.unique(np.asarray(tri_rows, dtype=int)[transition_tris])] = (
+            True
+        )
+        grad_arr[transition_rows, 2] = 0.0
 
     def _enforce_constraints(self, mesh: Mesh | None = None):
         """Invoke all constraint modules on the current mesh."""

--- a/tests/test_curved_1disk_outer_profile_source_audit.py
+++ b/tests/test_curved_1disk_outer_profile_source_audit.py
@@ -1,0 +1,170 @@
+import math
+
+from tools.diagnostics.curved_1disk_outer_profile_source_audit import (
+    ALLOWED_CLASSIFICATIONS,
+    SIGN_CONVENTION_CLASSIFICATIONS,
+    run_curved_1disk_outer_profile_source_audit,
+)
+
+
+def test_curved_1disk_outer_profile_source_audit_reports_schema() -> None:
+    report = run_curved_1disk_outer_profile_source_audit(include_selected=False)
+
+    diagnosis = report["diagnosis"]
+    assert diagnosis["classification"] in ALLOWED_CLASSIFICATIONS
+    assert (
+        diagnosis["sign_convention_classification"] in SIGN_CONVENTION_CLASSIFICATIONS
+    )
+    assert diagnosis["no_energy_rescaling"] is True
+    assert "Feature Contract" in diagnosis["summary"]
+    text = diagnosis["recommended_next_stream"]
+    assert "Do not rescale energy" in text
+    assert "hidden weights" in text
+    assert "tune to the theory curve" in text
+
+    assert len(report["cases"]) == 1
+    case = report["cases"][0]
+    assert case["label"] == "fixed_theory_theta"
+    assert case["shell_traces"]
+    assert case["first_collapse_stage"]
+    assert case["module_tilt_gradient_probe"]
+    assert case["perturbation_probes"]
+    assert case["profile_fit_controls"]
+
+
+def test_curved_1disk_outer_profile_source_shell_traces_have_channels() -> None:
+    report = run_curved_1disk_outer_profile_source_audit(include_selected=False)
+    traces = report["cases"][0]["shell_traces"]
+    labels = {trace["label"] for trace in traces}
+
+    assert {
+        "configured",
+        "after_geometric_enforcement",
+        "after_tilt_relaxation",
+        "after_shape_minimize",
+        "after_tangent_projection",
+    } <= labels
+    for trace in traces:
+        assert trace["shells"]
+        for row in trace["shells"]:
+            assert {
+                "theta_in_median",
+                "theta_out_median",
+                "theta_shared_median",
+                "z_median",
+                "curvature_median",
+                "leaflet_gap_median",
+                "symmetric_sum_abs",
+                "antisymmetric_gap_abs",
+                "windows",
+            } <= set(row)
+            assert math.isfinite(float(row["theta_in_median"]))
+            assert math.isfinite(float(row["theta_out_median"]))
+            assert math.isfinite(float(row["theta_shared_median"]))
+            assert math.isfinite(float(row["z_median"]))
+            assert math.isfinite(float(row["curvature_median"]))
+
+
+def test_curved_1disk_outer_profile_source_perturbations_reconcile() -> None:
+    report = run_curved_1disk_outer_profile_source_audit(include_selected=False)
+    probes = report["cases"][0]["perturbation_probes"]
+    names = {row["name"] for row in probes}
+
+    assert {"symmetric_leaflet", "antisymmetric_leaflet", "shape_log"} == names
+    for row in probes:
+        assert math.isfinite(float(row["total_delta"]))
+        assert math.isfinite(float(row["module_delta_sum"]))
+        assert abs(float(row["module_residual"])) < 1.0e-10
+        assert row["top_module_deltas"]
+
+
+def test_curved_1disk_outer_profile_source_profile_fit_controls() -> None:
+    report = run_curved_1disk_outer_profile_source_audit(include_selected=False)
+    controls = report["cases"][0]["profile_fit_controls"]
+    channels = {row["channel"] for row in controls["k1_by_channel"]}
+
+    assert {
+        "theta_in",
+        "theta_out",
+        "shared_signed",
+        "shared_abs",
+        "theta_outer_common_physical",
+    } == channels
+    for row in controls["k1_by_channel"]:
+        assert int(row["count"]) > 0
+        assert math.isfinite(float(row["lambda_fit"]))
+        assert math.isfinite(float(row["rel_rmse"]))
+    assert int(controls["log_all"]["count"]) > 0
+    assert math.isfinite(float(controls["log_all"]["slope_ratio"]))
+    assert int(controls["curvature_filtered_shell_count"]) >= 0
+    primary = controls["primary_physical_common_k1"]
+    assert primary["channel"] == "theta_outer_common_physical"
+    assert int(primary["count"]) > 0
+    assert math.isfinite(float(primary["lambda_fit"]))
+    assert math.isfinite(float(primary["rel_rmse"]))
+    comparison = controls["theory_comparison"]
+    for key in (
+        "physical_common_lambda_fit",
+        "physical_common_rel_rmse",
+        "physical_common_rim_amplitude",
+        "expected_lambda",
+        "rim_physical_theta_amplitude",
+        "theta_B_half",
+        "rim_physical_theta_amplitude_over_half_theta_B",
+        "measured_log_height_slope",
+        "expected_log_height_phi_star",
+        "expected_log_height_slope",
+        "log_height_slope_ratio",
+    ):
+        assert math.isfinite(float(comparison[key]))
+
+
+def test_curved_1disk_outer_profile_source_sign_convention_probe() -> None:
+    report = run_curved_1disk_outer_profile_source_audit(include_selected=False)
+    probe = report["cases"][0]["profile_fit_controls"]["leaflet_sign_convention_probe"]
+    fits = {row["name"]: row for row in probe["fits"]}
+
+    assert probe["classification"] in {
+        "diagnostic_leaflet_sign_convention_mismatch",
+        "runtime_relaxation_drives_antisymmetric_state",
+        "inconclusive",
+    }
+    assert {
+        "theta_common_raw",
+        "theta_antisym_raw",
+        "theta_common_flip",
+        "theta_antisym_flip",
+    } == set(fits)
+    for row in fits.values():
+        assert int(row["count"]) > 0
+        assert math.isfinite(float(row["lambda_fit"]))
+        assert math.isfinite(float(row["rel_rmse"]))
+        assert math.isfinite(float(row["rim_amplitude"]))
+        assert row["amplitude_sign"] in {"positive", "negative"}
+    assert math.isfinite(float(probe["log_height_slope_ratio"]))
+    assert "recommendation" in probe
+
+    if probe["good_k1_profile_location"] == "flipped_common_mode":
+        assert probe["classification"] == "diagnostic_leaflet_sign_convention_mismatch"
+        assert "diagnostic leaflet sign convention" in probe["recommendation"]
+    if probe["good_k1_profile_location"] == "raw_antisymmetric_physical_mode":
+        assert (
+            probe["classification"] == "runtime_relaxation_drives_antisymmetric_state"
+        )
+        assert "runtime leaflet coupling" in probe["recommendation"]
+
+
+def test_curved_1disk_outer_profile_source_classifies_k1_ok_log_suppressed() -> None:
+    report = run_curved_1disk_outer_profile_source_audit(include_selected=False)
+    diagnosis = report["diagnosis"]
+    controls = report["cases"][0]["profile_fit_controls"]
+    primary = controls["primary_physical_common_k1"]
+    comparison = controls["theory_comparison"]
+
+    assert diagnosis["classification"] == "outer_tilt_k1_ok_but_log_shape_suppressed"
+    assert float(primary["rel_rmse"]) < 0.10
+    assert abs(float(primary["lambda_ratio"]) - 1.0) <= 0.40
+    assert abs(float(comparison["log_height_slope_ratio"])) < 0.25
+    assert diagnosis["sign_convention_classification"] == (
+        "diagnostic_leaflet_sign_convention_mismatch"
+    )

--- a/tests/test_curved_1disk_rim_inner_tilt_profile_audit.py
+++ b/tests/test_curved_1disk_rim_inner_tilt_profile_audit.py
@@ -1,0 +1,100 @@
+import math
+
+from tools.diagnostics.curved_1disk_rim_inner_tilt_profile_audit import (
+    PROFILE_CLASSIFICATIONS,
+    RIM_CLASSIFICATIONS,
+    run_curved_1disk_rim_inner_tilt_profile_audit,
+)
+
+
+def test_curved_1disk_rim_inner_tilt_profile_audit_reports_schema() -> None:
+    report = run_curved_1disk_rim_inner_tilt_profile_audit(include_selected=False)
+
+    diagnosis = report["diagnosis"]
+    assert diagnosis["rim_inner_tilt_classification"] in RIM_CLASSIFICATIONS
+    assert diagnosis["outer_profile_classification"] in PROFILE_CLASSIFICATIONS
+    assert diagnosis["no_energy_rescaling"] is True
+    assert "Do not rescale energy" in diagnosis["recommended_next_stream"]
+    assert "tune coefficients" in diagnosis["recommended_next_stream"]
+
+    assert len(report["cases"]) == 1
+    case = report["cases"][0]
+    assert case["label"] == "fixed_theory_theta"
+    assert case["selected_theta"] is False
+    assert case["tilt_trace"]
+    assert case["module_gradient_probe"]
+    assert case["outer_profile_probe"]
+
+
+def test_curved_1disk_rim_inner_tilt_trace_is_finite() -> None:
+    report = run_curved_1disk_rim_inner_tilt_profile_audit(include_selected=False)
+    traces = report["cases"][0]["tilt_trace"]
+    labels = {row["label"] for row in traces}
+
+    assert {
+        "configured",
+        "after_geometric_enforcement",
+        "after_tilt_relaxation",
+        "after_rim_tilt_enforcement",
+    } <= labels
+    for trace in traces:
+        assert trace["shells"]
+        for region in ("rim", "outer_support"):
+            summary = trace[region]
+            assert int(summary["row_count"]) >= 0
+            assert math.isfinite(float(summary["theta_in_median"]))
+            assert math.isfinite(float(summary["theta_out_median"]))
+            assert math.isfinite(float(summary["theta_shared_median"]))
+
+
+def test_curved_1disk_rim_inner_tilt_module_and_energy_reconcile() -> None:
+    report = run_curved_1disk_rim_inner_tilt_profile_audit(include_selected=False)
+    case = report["cases"][0]
+
+    for module_name in ("bending_tilt_in", "bending_tilt_out"):
+        row = case["module_gradient_probe"][module_name]
+        assert math.isfinite(float(row["energy"]))
+        assert math.isfinite(float(row["shape_grad_norm"]))
+        assert math.isfinite(float(row["tilt_grad_norm"]))
+        assert set(row["shape_grad_z_abs_by_region"]) == {
+            "disk",
+            "shared_rim",
+            "outer_support",
+            "outer_free",
+        }
+        assert set(row["tilt_grad_abs_by_region"]) == {
+            "disk",
+            "shared_rim",
+            "outer_support",
+            "outer_free",
+        }
+
+    recon = case["energy_reconciliation"]
+    assert math.isfinite(float(recon["total_delta"]))
+    assert math.isfinite(float(recon["module_delta_sum"]))
+    assert abs(float(recon["module_residual"])) < 1.0e-10
+    assert recon["module_deltas"]
+
+
+def test_curved_1disk_rim_inner_tilt_profile_channels_are_reported() -> None:
+    report = run_curved_1disk_rim_inner_tilt_profile_audit(include_selected=False)
+    profile = report["cases"][0]["outer_profile_probe"]
+
+    assert profile["outer_k1_shared"]["count"] > 0
+    assert profile["outer_height_log"]["count"] > 0
+    assert profile["outer_curvature"]["count"] > 0
+    assert profile["fit_window_shells"]
+    for row in profile["fit_window_shells"]:
+        assert {
+            "theta_in",
+            "theta_out",
+            "theta_shared",
+            "z",
+            "J",
+            "leaflet_gap",
+        } <= set(row)
+        assert math.isfinite(float(row["theta_in"]))
+        assert math.isfinite(float(row["theta_out"]))
+        assert math.isfinite(float(row["theta_shared"]))
+        assert math.isfinite(float(row["z"]))
+        assert math.isfinite(float(row["J"]))

--- a/tests/test_curved_1disk_shape_direction_audit.py
+++ b/tests/test_curved_1disk_shape_direction_audit.py
@@ -1,0 +1,63 @@
+import math
+
+import pytest
+
+from tools.diagnostics.curved_1disk_shape_direction_audit import (
+    ALLOWED_CLASSIFICATIONS,
+    run_curved_1disk_shape_direction_audit,
+)
+
+
+def test_curved_1disk_shape_direction_audit_reports_required_schema() -> None:
+    report = run_curved_1disk_shape_direction_audit(horizons=(1,))
+
+    assert report["diagnosis"]["classification"] in ALLOWED_CLASSIFICATIONS
+    assert report["diagnosis"]["no_energy_rescaling"] is True
+    assert "Feature Contract" in report["diagnosis"]["summary"]
+    assert "do not rescale" in report["diagnosis"]["recommended_next_stream"]
+
+    directions = {row["name"]: row for row in report["direction_summaries"]}
+    assert {
+        "outer_log_trumpet",
+        "projected_gradient_descent",
+        "log_residual_gradient",
+        "near_support_gradient",
+        "far_field_gradient",
+        "high_frequency_gradient",
+        "area_weighted_gradient_probe",
+        "shell_normalized_gradient_probe",
+        "support_suppressed_gradient_probe",
+    } <= set(directions)
+    assert directions["outer_log_trumpet"]["norm"] == pytest.approx(1.0)
+    assert directions["outer_log_trumpet"]["nonzero_rows"] > 0
+
+    log_probe = next(
+        row
+        for row in report["directional_probes"]
+        if row["name"] == "outer_log_trumpet" and not row["relax_tilts"]
+    )
+    assert bool(log_probe["accepted_by_decrease"]) is True
+    assert float(log_probe["total_delta"]) < 0.0
+
+
+def test_curved_1disk_shape_direction_audit_reconciles_and_replays_updates() -> None:
+    report = run_curved_1disk_shape_direction_audit(horizons=(1,))
+
+    for probe in report["directional_probes"]:
+        assert math.isfinite(float(probe["total_delta"]))
+        assert math.isfinite(float(probe["module_delta_sum"]))
+        assert abs(float(probe["module_residual"])) < 1.0e-10
+        assert probe["top_module_deltas"]
+        assert float(probe["direction_norm"]) == pytest.approx(0.0) or float(
+            probe["direction_norm"]
+        ) == pytest.approx(1.0)
+
+    replay = report["accepted_update_replay"]
+    assert len(replay) == 1
+    row = replay[0]
+    assert int(row["n_steps"]) == 1
+    assert bool(row["step_success"]) is True
+    assert float(row["xy_delta_abs_sum"]) < 1.0e-10
+    assert float(row["z_delta_abs_sum"]) > 0.0
+    assert "outer_log_trumpet" in row["mode_alignment"]
+    assert row["z_delta_by_shell"]

--- a/tests/test_curved_1disk_support_gradient_fix_acceptance.py
+++ b/tests/test_curved_1disk_support_gradient_fix_acceptance.py
@@ -1,0 +1,46 @@
+from tools.diagnostics.curved_1disk_shape_direction_audit import (
+    run_curved_1disk_shape_direction_audit,
+)
+from tools.diagnostics.curved_1disk_shared_rim_phi_target_audit import THEORY_THETA_B
+from tools.diagnostics.curved_1disk_theory_benchmark import _run_curved_theta_candidate
+
+
+def test_curved_1disk_support_transition_band_no_longer_dominates_shape_update() -> (
+    None
+):
+    report = run_curved_1disk_shape_direction_audit(horizons=(1,))
+
+    assert report["diagnosis"]["classification"] != "support_shell_gradient_dominates"
+    step = report["accepted_update_replay"][0]
+    support_cos = abs(float(step["mode_alignment"]["near_support_gradient"]["cosine"]))
+    assert support_cos < 0.40
+
+
+def test_curved_1disk_fixed_theta_short_relaxation_moves_log_slope_physical() -> None:
+    report = run_curved_1disk_shape_direction_audit(horizons=(1,))
+
+    step = report["accepted_update_replay"][0]
+    assert float(step["profile_after"]["outer_log_slope"]) > 0.0
+    assert float(step["xy_delta_abs_sum"]) < 1.0e-10
+    assert float(step["z_delta_abs_sum"]) > 0.0
+
+
+def test_curved_1disk_log_direction_remains_valid_descent_after_support_fix() -> None:
+    report = run_curved_1disk_shape_direction_audit(horizons=(1,))
+
+    log_probe = next(
+        row
+        for row in report["directional_probes"]
+        if row["name"] == "outer_log_trumpet" and not row["relax_tilts"]
+    )
+    assert bool(log_probe["accepted_by_armijo"]) is True
+    assert float(log_probe["total_delta"]) < 0.0
+
+
+def test_curved_1disk_transition_regularization_does_not_prefer_high_branch() -> None:
+    theory = _run_curved_theta_candidate(float(THEORY_THETA_B))
+    high = _run_curved_theta_candidate(0.22)
+
+    theory_energy = float(theory["near_rim"]["total_energy"])
+    high_energy = float(high["near_rim"]["total_energy"])
+    assert theory_energy <= high_energy

--- a/tests/test_curved_1disk_theory_benchmark.py
+++ b/tests/test_curved_1disk_theory_benchmark.py
@@ -26,21 +26,18 @@ def test_curved_1disk_theory_benchmark_reports_current_tensionless_miss() -> Non
 
     assert report["benchmark_lock_passed"] is False
     assert set(report["benchmark_lock_failures"]) == {
-        "theta_B_opt",
         "theta_in_half_split",
         "inner_i1_fit",
         "outer_k1_fit",
         "outer_height_log_fit",
         "outer_curvature",
-        "total_energy",
         "inner_elastic",
         "outer_elastic",
-        "contact_energy",
         "outer_log_window_sensitivity",
     }
 
     theta_b_num = float(report["theta_B_selected"])
-    assert theta_b_num < 0.75 * float(theory["theta_B_opt"])
+    assert theta_b_num > 1.05 * float(theory["theta_B_opt"])
 
     near_rim = report["near_rim"]
     assert float(near_rim["phi_over_theta_B"]) == pytest.approx(0.5, rel=0.10)
@@ -51,7 +48,7 @@ def test_curved_1disk_theory_benchmark_reports_current_tensionless_miss() -> Non
 
     fits = report["fits"]
     inner_fit = fits["inner_i1"]
-    assert float(inner_fit["lambda_fit"]) > 4.0 * float(theory["lambda_theory"])
+    assert float(inner_fit["lambda_fit"]) > 3.0 * float(theory["lambda_theory"])
     assert float(inner_fit["rel_rmse"]) > 0.05
     assert inner_fit["window"] == [0.25, 0.75]
 
@@ -67,14 +64,14 @@ def test_curved_1disk_theory_benchmark_reports_current_tensionless_miss() -> Non
     assert height_fit["window"] == [3.0, 10.0]
 
     curvature = report["outer_curvature"]
-    assert 0.01 < float(curvature["mean_abs_J"]) < 0.05
+    assert float(curvature["mean_abs_J"]) > 0.05
     assert float(curvature["p95_abs_J"]) > 0.15
 
     energies = report["energies"]
-    assert float(energies["total_numeric"]) > float(theory["F_tot"])
-    assert 0.001 < float(energies["inner_elastic_numeric"]) < 0.01
+    assert float(energies["total_numeric"]) < float(theory["F_tot"])
+    assert float(energies["inner_elastic_numeric"]) > 0.01
     assert float(energies["outer_elastic_numeric"]) > 1.0
-    assert abs(float(energies["contact_numeric"])) < abs(float(theory["F_cont"]))
+    assert abs(float(energies["contact_numeric"])) > abs(float(theory["F_cont"]))
 
     outer_sensitivity = report["outer_window_sensitivity"]
     assert float(outer_sensitivity["lambda_fit_spread"]) <= 0.10

--- a/tests/test_curved_1disk_transition_band_ownership_audit.py
+++ b/tests/test_curved_1disk_transition_band_ownership_audit.py
@@ -1,0 +1,69 @@
+import math
+
+from tools.diagnostics.curved_1disk_transition_band_ownership_audit import (
+    ALLOWED_CLASSIFICATIONS,
+    THETA_CANDIDATES,
+    run_curved_1disk_transition_band_ownership_audit,
+)
+
+
+def test_transition_band_ownership_audit_reports_required_schema() -> None:
+    report = run_curved_1disk_transition_band_ownership_audit()
+
+    assert report["diagnosis"]["classification"] in ALLOWED_CLASSIFICATIONS
+    assert report["diagnosis"]["no_energy_rescaling"] is True
+    recommendation = report["diagnosis"]["recommendation"].lower()
+    assert "rescale" not in recommendation
+    assert "hidden weights" not in recommendation
+    assert "tune coefficients" not in recommendation
+
+    band = report["transition_band"]
+    assert int(band["row_count"]) > 0
+    assert "outer_support" in set(band["row_regions"])
+    assert report["region_ownership"]["modules"]
+    assert report["region_ownership"]["totals"]["gradient_transition_fraction"] >= 0.0
+
+
+def test_transition_band_ownership_audit_reconciles_gradients_and_theta_rows() -> None:
+    report = run_curved_1disk_transition_band_ownership_audit()
+
+    residual = float(
+        report["module_gradient_reconciliation"]["sum_projected_minus_full_norm"]
+    )
+    assert residual < 1.0e-8
+
+    for row in report["region_ownership"]["modules"]:
+        assert math.isfinite(float(row["projected_gradient_norm_total"]))
+        assert math.isfinite(float(row["projected_gradient_norm_transition_band"]))
+        assert math.isfinite(float(row["energy_total"]))
+        assert math.isfinite(float(row["energy_transition_band"]))
+
+    theta_rows = report["theta_candidate_ordering"]
+    assert [float(row["theta_B"]) for row in theta_rows] == list(THETA_CANDIDATES)
+    assert sum(bool(row["selected_by_total_energy"]) for row in theta_rows) == 1
+    assert (
+        sum(
+            bool(row["selected_without_transition_band_attributed"])
+            for row in theta_rows
+        )
+        == 1
+    )
+
+
+def test_transition_band_regularization_reduces_gradient_dominance_and_orders_theta() -> (
+    None
+):
+    report = run_curved_1disk_transition_band_ownership_audit()
+
+    totals = report["region_ownership"]["totals"]
+    assert float(totals["gradient_transition_fraction"]) < 0.95
+    assert (
+        report["diagnosis"]["classification"]
+        != "theta_ordering_depends_on_support_energy"
+    )
+
+    theta_rows = report["theta_candidate_ordering"]
+    selected = [
+        float(row["theta_B"]) for row in theta_rows if row["selected_by_total_energy"]
+    ]
+    assert selected and selected[0] > 0.12

--- a/tests/test_curved_1disk_trumpet_descent_audit.py
+++ b/tests/test_curved_1disk_trumpet_descent_audit.py
@@ -1,0 +1,57 @@
+import math
+
+import pytest
+
+from tools.diagnostics.curved_1disk_trumpet_descent_audit import (
+    ALLOWED_CLASSIFICATIONS,
+    run_curved_1disk_trumpet_descent_audit,
+)
+
+
+def test_curved_1disk_trumpet_descent_audit_reports_required_schema() -> None:
+    report = run_curved_1disk_trumpet_descent_audit(epsilons=(1.0e-5,))
+
+    assert report["mode_construction"]["z_only"] is True
+    assert report["mode_construction"]["amplitude_is_probe_not_parameter"] is True
+    assert report["mode_construction"]["no_energy_rescaling"] is True
+    assert int(report["mode_construction"]["outer_free_row_count"]) > 0
+    assert report["diagnosis"]["classification"] in ALLOWED_CLASSIFICATIONS
+    assert "rescale" in report["diagnosis"]["recommended_next_stream"]
+    assert "do not rescale" in report["diagnosis"]["recommended_next_stream"]
+
+    modes = {mode["name"]: mode for mode in report["modes"]}
+    assert set(modes) == {
+        "outer_log_trumpet",
+        "outer_log_trumpet_flipped",
+        "outer_local_shell_bump",
+    }
+    assert modes["outer_log_trumpet"]["nonzero_rows"] > 0
+    assert modes["outer_log_trumpet"]["mode_max_abs"] == pytest.approx(1.0)
+    assert modes["outer_log_trumpet_flipped"]["mode_norm"] == pytest.approx(
+        modes["outer_log_trumpet"]["mode_norm"]
+    )
+    updates = report["accepted_update_alignment"]
+    assert [int(row["n_steps"]) for row in updates] == [1, 5]
+    for row in updates:
+        assert bool(row["step_success"]) is True
+        assert float(row["xy_delta_abs_sum"]) < 1.0e-10
+        assert float(row["z_delta_abs_sum"]) > 0.0
+        assert "outer_log_trumpet" in row["mode_alignment"]
+
+
+def test_curved_1disk_trumpet_descent_audit_reconciles_module_deltas() -> None:
+    report = run_curved_1disk_trumpet_descent_audit(epsilons=(1.0e-5,))
+
+    for mode in report["modes"]:
+        alignment = mode["gradient_alignment"]
+        assert math.isfinite(float(alignment["raw_dot_mode"]))
+        assert math.isfinite(float(alignment["projected_dot_mode"]))
+        enforcement = mode["enforcement_probe"]
+        assert float(enforcement["z_before_abs_sum"]) >= 0.0
+        assert float(enforcement["xy_after_abs_sum"]) < 1.0e-10
+
+        for case in mode["finite_difference_cases"]:
+            assert math.isfinite(float(case["total_delta"]))
+            assert math.isfinite(float(case["module_delta_sum"]))
+            assert abs(float(case["module_residual"])) < 1.0e-10
+            assert case["top_module_deltas"]

--- a/tools/diagnostics/curved_1disk_outer_profile_source_audit.py
+++ b/tools/diagnostics/curved_1disk_outer_profile_source_audit.py
@@ -1,0 +1,744 @@
+#!/usr/bin/env python3
+"""Identify the source of curved 1-disk outer-profile mismatches.
+
+The audit is diagnostic-only.  It traces when the outer leaflet pair becomes
+anti-symmetric and probes symmetric, anti-symmetric, and shape-only
+perturbations through the current runtime energy path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+
+import numpy as np
+from scipy.special import k1
+
+from modules.energy import bending_tilt_in, bending_tilt_out
+from tools.diagnostics.curved_1disk_rim_inner_tilt_profile_audit import (
+    _abs_by_region,
+    _field_trace,
+    _profile_source_probe,
+    _row_region,
+)
+from tools.diagnostics.curved_1disk_shape_propagation_blocker import (
+    _build_minimizer,
+    _restore_state,
+)
+from tools.diagnostics.curved_1disk_shared_rim_phi_target_audit import THEORY_THETA_B
+from tools.diagnostics.curved_1disk_theory_benchmark import (
+    OUTER_K1_WINDOW,
+    OUTER_LOG_WINDOW,
+    SHAPE_STEPS,
+    _relative_rmse,
+    _run_canonical_schedule,
+    _shell_profile,
+    _window_rows,
+)
+from tools.diagnostics.curved_1disk_trumpet_descent_audit import (
+    _breakdown_total,
+    _module_deltas,
+)
+from tools.diagnostics.curved_disk_theory import (
+    compute_curved_disk_theory,
+    tex_reference_params,
+)
+from tools.diagnostics.free_disk_profile_fits import _fit_k1, _fit_log
+
+ALLOWED_CLASSIFICATIONS = {
+    "leaflet_relaxation_drives_antisymmetric_state",
+    "bending_tilt_sign_or_ownership_drives_cancellation",
+    "support_transition_mask_seeds_leaflet_cancellation",
+    "shape_tilt_coupling_missing_after_valid_shape_update",
+    "outer_tilt_k1_ok_but_log_shape_suppressed",
+    "far_boundary_or_window_artifact",
+    "inconclusive",
+}
+SIGN_CONVENTION_CLASSIFICATIONS = {
+    "diagnostic_leaflet_sign_convention_mismatch",
+    "runtime_relaxation_drives_antisymmetric_state",
+    "inconclusive",
+}
+
+
+def _capture_state(mesh) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    return (
+        mesh.positions_view().copy(order="F"),
+        mesh.tilts_view().copy(order="F"),
+        mesh.tilts_in_view().copy(order="F"),
+        mesh.tilts_out_view().copy(order="F"),
+    )
+
+
+def _radius_labels(mesh) -> np.ndarray:
+    return np.round(np.linalg.norm(mesh.positions_view()[:, :2], axis=1), decimals=8)
+
+
+def _window_masks(mesh) -> dict[str, np.ndarray]:
+    params = tex_reference_params()
+    radius = float(params.radius)
+    labels = _radius_labels(mesh)
+    max_radius = float(np.max(labels))
+    free_outer = np.array(
+        [_row_region(mesh, row) == "outer_free" for row in range(len(labels))],
+        dtype=bool,
+    )
+    free_radii = sorted(
+        float(v)
+        for v in set(labels[free_outer])
+        if float(v) > radius + 1.0e-6 and float(v) < max_radius - 1.0e-6
+    )
+    first_free = set(free_radii[:2])
+    far_cut = (
+        free_radii[max(0, int(0.75 * (len(free_radii) - 1)))]
+        if free_radii
+        else max_radius
+    )
+    return {
+        "outer_support": np.array(
+            [_row_region(mesh, row) == "outer_support" for row in range(len(labels))],
+            dtype=bool,
+        ),
+        "first_free": free_outer & np.isin(labels, list(first_free)),
+        "k1_window": free_outer
+        & (labels >= OUTER_K1_WINDOW[0] * radius)
+        & (labels <= OUTER_K1_WINDOW[1] * radius),
+        "log_window": free_outer
+        & (labels >= OUTER_LOG_WINDOW[0] * radius)
+        & (labels <= OUTER_LOG_WINDOW[1] * radius),
+        "far_boundary": free_outer & (labels >= far_cut),
+    }
+
+
+def _shell_trace(mesh, *, label: str) -> dict[str, object]:
+    base = _field_trace(mesh, label=label)
+    positions = mesh.positions_view()
+    shell_rows = _shell_profile(mesh)
+    by_radius = {round(float(row["radius"]), 8): row for row in shell_rows}
+    masks = _window_masks(mesh)
+    for row in base["shells"]:
+        radius_key = round(float(row["radius"]), 8)
+        profile_row = by_radius.get(radius_key, {})
+        theta_in = float(row["theta_in_median"])
+        theta_out = float(row["theta_out_median"])
+        row["z_median"] = float(profile_row.get("z", 0.0))
+        row["curvature_median"] = float(profile_row.get("J", 0.0))
+        row["leaflet_gap_median"] = float(abs(theta_in - theta_out))
+        row["symmetric_sum_abs"] = float(abs(theta_in + theta_out))
+        row["antisymmetric_gap_abs"] = float(abs(theta_in - theta_out))
+        shell_mask = np.isclose(_radius_labels(mesh), radius_key, atol=5.0e-9)
+        row["windows"] = sorted(
+            name for name, mask in masks.items() if np.any(mask & shell_mask)
+        )
+        row["z_span"] = float(
+            np.max(positions[shell_mask, 2]) - np.min(positions[shell_mask, 2])
+        )
+    return base
+
+
+def _module_tilt_gradient_probe(minim) -> dict[str, object]:
+    mesh = minim.mesh
+    positions = mesh.positions_view()
+    common = {
+        "mesh": mesh,
+        "global_params": mesh.global_parameters,
+        "param_resolver": minim.param_resolver,
+        "positions": positions,
+        "index_map": mesh.vertex_index_to_row,
+        "ctx": None,
+        "tilts_in": mesh.tilts_in_view(),
+        "tilts_out": mesh.tilts_out_view(),
+    }
+    out: dict[str, object] = {}
+    for name, module, tilt_key in (
+        ("bending_tilt_in", bending_tilt_in, "tilt_in"),
+        ("bending_tilt_out", bending_tilt_out, "tilt_out"),
+    ):
+        grad = np.zeros_like(positions)
+        tin_grad = np.zeros_like(mesh.tilts_in_view())
+        tout_grad = np.zeros_like(mesh.tilts_out_view())
+        energy = module.compute_energy_and_gradient_array(
+            grad_arr=grad,
+            tilt_in_grad_arr=tin_grad,
+            tilt_out_grad_arr=tout_grad,
+            **common,
+        )
+        tilt_grad = tin_grad if tilt_key == "tilt_in" else tout_grad
+        _, theta_in, theta_out, _ = _radial_components(mesh)
+        theta = theta_in if tilt_key == "tilt_in" else theta_out
+        radial_grad = _radial_projection(mesh, tilt_grad)
+        out[name] = {
+            "energy": float(energy),
+            "tilt_grad_norm": float(np.linalg.norm(tilt_grad)),
+            "tilt_grad_abs_by_region": _abs_by_region(
+                mesh, np.linalg.norm(tilt_grad, axis=1)
+            ),
+            "radial_grad_dot_theta_by_window": _window_dot_summary(
+                mesh, radial_grad, theta
+            ),
+        }
+    return out
+
+
+def _radial_components(mesh) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    positions = mesh.positions_view()
+    radii = np.linalg.norm(positions[:, :2], axis=1)
+    r_hat = np.zeros_like(positions)
+    good = radii > 1.0e-12
+    r_hat[good, :2] = positions[good, :2] / radii[good, None]
+    theta_in = np.einsum("ij,ij->i", mesh.tilts_in_view(), r_hat)
+    theta_out = np.einsum("ij,ij->i", mesh.tilts_out_view(), r_hat)
+    return radii, theta_in, theta_out, 0.5 * (theta_in + theta_out)
+
+
+def theta_outer_common_physical(
+    theta_in: np.ndarray, theta_out: np.ndarray
+) -> np.ndarray:
+    """Return the physical outer common mode from stored leaflet components.
+
+    The diagnostic radial components for ``theta_in`` and ``theta_out`` are
+    stored in opposite local leaflet frames on the outer membrane, so the
+    physical same-sign leaflet mode is their difference, not their raw sum.
+    """
+    return 0.5 * (
+        np.asarray(theta_in, dtype=float) - np.asarray(theta_out, dtype=float)
+    )
+
+
+def _radial_projection(mesh, values: np.ndarray) -> np.ndarray:
+    positions = mesh.positions_view()
+    radii = np.linalg.norm(positions[:, :2], axis=1)
+    r_hat = np.zeros_like(positions)
+    good = radii > 1.0e-12
+    r_hat[good, :2] = positions[good, :2] / radii[good, None]
+    return np.einsum("ij,ij->i", values, r_hat)
+
+
+def _window_dot_summary(mesh, lhs: np.ndarray, rhs: np.ndarray) -> dict[str, float]:
+    masks = _window_masks(mesh)
+    out = {}
+    for name, mask in masks.items():
+        if np.any(mask):
+            out[name] = float(np.dot(lhs[mask], rhs[mask]))
+        else:
+            out[name] = 0.0
+    return out
+
+
+def _apply_tilt_mode(mesh, mode: str, epsilon: float) -> None:
+    positions = mesh.positions_view()
+    radii = np.linalg.norm(positions[:, :2], axis=1)
+    r_hat = np.zeros_like(positions)
+    good = radii > 1.0e-12
+    r_hat[good, :2] = positions[good, :2] / radii[good, None]
+    mask = _window_masks(mesh)["k1_window"]
+    delta = np.zeros_like(positions)
+    delta[mask] = float(epsilon) * r_hat[mask]
+    if mode == "symmetric_leaflet":
+        mesh.tilts_in_view()[:] += delta
+        mesh.tilts_out_view()[:] += delta
+    elif mode == "antisymmetric_leaflet":
+        mesh.tilts_in_view()[:] += delta
+        mesh.tilts_out_view()[:] -= delta
+    else:
+        raise ValueError(f"Unknown tilt perturbation mode: {mode}")
+    mesh.touch_tilts_in()
+    mesh.touch_tilts_out()
+
+
+def _apply_shape_log_mode(mesh, epsilon: float) -> None:
+    positions = mesh.positions_view().copy(order="F")
+    radii = np.linalg.norm(positions[:, :2], axis=1)
+    mask = _window_masks(mesh)["log_window"]
+    if np.any(mask):
+        r_min = float(np.min(radii[mask]))
+        values = np.log(np.maximum(radii, r_min) / max(r_min, 1.0e-12))
+        scale = float(np.max(np.abs(values[mask])))
+        if scale > 0.0:
+            positions[mask, 2] += float(epsilon) * values[mask] / scale
+    for row, vid in enumerate(mesh.vertex_ids):
+        mesh.vertices[int(vid)].position[:] = positions[row]
+    mesh.increment_version()
+    mesh.build_position_cache()
+
+
+def _perturbation_probes(minim, *, epsilon: float = 1.0e-6) -> list[dict[str, object]]:
+    mesh = minim.mesh
+    baseline = minim.compute_energy_breakdown()
+    state = _capture_state(mesh)
+    rows = []
+    for name in ("symmetric_leaflet", "antisymmetric_leaflet", "shape_log"):
+        if name == "shape_log":
+            _apply_shape_log_mode(mesh, epsilon)
+        else:
+            _apply_tilt_mode(mesh, name, epsilon)
+        perturbed = minim.compute_energy_breakdown()
+        deltas = _module_deltas(baseline, perturbed)
+        total_delta = _breakdown_total(perturbed) - _breakdown_total(baseline)
+        module_sum = _breakdown_total(deltas)
+        rows.append(
+            {
+                "name": name,
+                "epsilon": float(epsilon),
+                "total_delta": float(total_delta),
+                "module_delta_sum": float(module_sum),
+                "module_residual": float(total_delta - module_sum),
+                "module_deltas": deltas,
+                "top_module_deltas": [
+                    {"module": str(module), "delta": float(delta)}
+                    for module, delta in sorted(
+                        deltas.items(), key=lambda item: abs(item[1]), reverse=True
+                    )[:6]
+                ],
+            }
+        )
+        _restore_state(mesh, *state)
+    return rows
+
+
+def _fit_k1_channel(
+    shell_rows: list[dict[str, float]],
+    *,
+    channel: str,
+    radius: float,
+    lambda_theory: float,
+    last_free_shell_radius: float,
+) -> dict[str, object]:
+    rows = _window_rows(
+        shell_rows,
+        radius=radius,
+        window=OUTER_K1_WINDOW,
+        last_free_shell_radius=last_free_shell_radius,
+    )
+    r = np.asarray([float(row["radius"]) for row in rows], dtype=float)
+    if channel == "theta_in":
+        y = np.asarray([float(row["theta_in"]) for row in rows], dtype=float)
+    elif channel == "theta_out":
+        y = np.asarray([float(row["theta_out"]) for row in rows], dtype=float)
+    elif channel == "shared_abs":
+        y = np.asarray([abs(float(row["theta_shared"])) for row in rows], dtype=float)
+    elif channel == "theta_outer_common_physical":
+        theta_in = np.asarray([float(row["theta_in"]) for row in rows], dtype=float)
+        theta_out = np.asarray([float(row["theta_out"]) for row in rows], dtype=float)
+        y = theta_outer_common_physical(theta_in, theta_out)
+    else:
+        y = np.asarray([float(row["theta_shared"]) for row in rows], dtype=float)
+    amp, lam_fit, _ = _fit_k1(r, y, float(radius))
+    yhat = amp * k1(lam_fit * r) / k1(lam_fit * float(radius))
+    return {
+        "channel": channel,
+        "count": int(len(r)),
+        "amplitude_fit": float(amp),
+        "lambda_fit": float(lam_fit),
+        "lambda_ratio": float(lam_fit / lambda_theory),
+        "rel_rmse": _relative_rmse(y, yhat),
+    }
+
+
+def _fit_k1_values(
+    rows: list[dict[str, float]],
+    *,
+    name: str,
+    values: np.ndarray,
+    radius: float,
+    lambda_theory: float,
+) -> dict[str, object]:
+    r = np.asarray([float(row["radius"]) for row in rows], dtype=float)
+    amp, lam_fit, _ = _fit_k1(r, values, float(radius))
+    yhat = amp * k1(lam_fit * r) / k1(lam_fit * float(radius))
+    return {
+        "name": name,
+        "count": int(len(r)),
+        "rim_amplitude": float(amp),
+        "amplitude_sign": "positive" if float(amp) >= 0.0 else "negative",
+        "lambda_fit": float(lam_fit),
+        "lambda_ratio": float(lam_fit / lambda_theory),
+        "rel_rmse": _relative_rmse(values, yhat),
+    }
+
+
+def _leaflet_sign_convention_probe(
+    shell_rows: list[dict[str, float]],
+    *,
+    radius: float,
+    lambda_theory: float,
+    last_free_shell_radius: float,
+    log_slope_ratio: float,
+) -> dict[str, object]:
+    rows = _window_rows(
+        shell_rows,
+        radius=radius,
+        window=OUTER_K1_WINDOW,
+        last_free_shell_radius=last_free_shell_radius,
+    )
+    theta_in = np.asarray([float(row["theta_in"]) for row in rows], dtype=float)
+    theta_out = np.asarray([float(row["theta_out"]) for row in rows], dtype=float)
+    common_raw = 0.5 * (theta_in + theta_out)
+    antisym_raw = 0.5 * (theta_in - theta_out)
+    common_flip = 0.5 * (theta_in - theta_out)
+    antisym_flip = 0.5 * (theta_in + theta_out)
+    fits = [
+        _fit_k1_values(
+            rows,
+            name="theta_common_raw",
+            values=common_raw,
+            radius=radius,
+            lambda_theory=lambda_theory,
+        ),
+        _fit_k1_values(
+            rows,
+            name="theta_antisym_raw",
+            values=antisym_raw,
+            radius=radius,
+            lambda_theory=lambda_theory,
+        ),
+        _fit_k1_values(
+            rows,
+            name="theta_common_flip",
+            values=common_flip,
+            radius=radius,
+            lambda_theory=lambda_theory,
+        ),
+        _fit_k1_values(
+            rows,
+            name="theta_antisym_flip",
+            values=antisym_flip,
+            radius=radius,
+            lambda_theory=lambda_theory,
+        ),
+    ]
+    by_name = {str(row["name"]): row for row in fits}
+    raw_common_good = _is_good_k1_fit(by_name["theta_common_raw"])
+    flip_common_good = _is_good_k1_fit(by_name["theta_common_flip"])
+    raw_antisym_good = _is_good_k1_fit(by_name["theta_antisym_raw"])
+    if raw_common_good:
+        location = "raw_common_mode"
+        classification = "inconclusive"
+        recommendation = (
+            "Raw common mode already fits K1; inspect remaining height/curvature "
+            "coupling before changing leaflet signs."
+        )
+    elif flip_common_good:
+        location = "flipped_common_mode"
+        classification = "diagnostic_leaflet_sign_convention_mismatch"
+        recommendation = (
+            "Flipped common mode fits K1 well; inspect and fix diagnostic leaflet "
+            "sign convention before changing runtime physics."
+        )
+    elif raw_antisym_good:
+        location = "raw_antisymmetric_physical_mode"
+        classification = "runtime_relaxation_drives_antisymmetric_state"
+        recommendation = (
+            "Only the antisymmetric physical mode fits K1; inspect runtime leaflet "
+            "coupling, bending-tilt energy signs, or tilt relaxation signs."
+        )
+    else:
+        location = "no_good_k1_mode"
+        classification = "inconclusive"
+        recommendation = (
+            "No common or antisymmetric candidate cleanly fits K1; continue with "
+            "shape/curvature and window diagnostics before changing runtime physics."
+        )
+    return {
+        "fits": fits,
+        "log_height_slope_ratio": float(log_slope_ratio),
+        "good_k1_profile_location": location,
+        "classification": classification,
+        "allowed_classifications": sorted(SIGN_CONVENTION_CLASSIFICATIONS),
+        "recommendation": recommendation,
+    }
+
+
+def _is_good_k1_fit(row: dict[str, object]) -> bool:
+    return (
+        int(row["count"]) > 0
+        and abs(float(row["lambda_ratio"]) - 1.0) <= 0.40
+        and float(row["rel_rmse"]) <= 0.10
+        and abs(float(row["rim_amplitude"])) > 1.0e-8
+    )
+
+
+def _is_good_k1_channel(row: dict[str, object]) -> bool:
+    return (
+        int(row["count"]) > 0
+        and abs(float(row["lambda_ratio"]) - 1.0) <= 0.40
+        and float(row["rel_rmse"]) <= 0.10
+        and abs(float(row["amplitude_fit"])) > 1.0e-8
+    )
+
+
+def _profile_fit_controls(mesh, *, theta_b: float) -> dict[str, object]:
+    params = tex_reference_params()
+    theory = compute_curved_disk_theory(params)
+    shell_rows = _shell_profile(mesh)
+    radius = float(params.radius)
+    radii = [float(row["radius"]) for row in shell_rows]
+    max_radius = float(max(radii))
+    free_outer_radii = sorted(
+        rr for rr in radii if rr > radius + 1.0e-6 and rr < max_radius - 1.0e-6
+    )
+    last_free = float(free_outer_radii[-1]) if free_outer_radii else max_radius
+    log_rows = _window_rows(
+        shell_rows,
+        radius=radius,
+        window=OUTER_LOG_WINDOW,
+        last_free_shell_radius=last_free,
+    )
+    clean_log_rows = [row for row in log_rows if abs(float(row["J"])) <= 0.05]
+    log_clean = _fit_log_channel(
+        clean_log_rows,
+        radius=radius,
+        slope_theory=0.5 * float(theta_b) * radius,
+    )
+    log_all = _fit_log_channel(
+        log_rows,
+        radius=radius,
+        slope_theory=0.5 * float(theta_b) * radius,
+    )
+    physical_common_k1 = _fit_k1_channel(
+        shell_rows,
+        channel="theta_outer_common_physical",
+        radius=radius,
+        lambda_theory=float(theory.lambda_value),
+        last_free_shell_radius=last_free,
+    )
+    phi_star = 0.5 * float(theta_b)
+    expected_log_slope = phi_star * radius
+    return {
+        "k1_by_channel": [
+            _fit_k1_channel(
+                shell_rows,
+                channel=channel,
+                radius=radius,
+                lambda_theory=float(theory.lambda_value),
+                last_free_shell_radius=last_free,
+            )
+            for channel in (
+                "theta_in",
+                "theta_out",
+                "shared_signed",
+                "shared_abs",
+                "theta_outer_common_physical",
+            )
+        ],
+        "primary_physical_common_k1": physical_common_k1,
+        "theory_comparison": {
+            "physical_common_lambda_fit": float(physical_common_k1["lambda_fit"]),
+            "physical_common_rel_rmse": float(physical_common_k1["rel_rmse"]),
+            "physical_common_rim_amplitude": float(physical_common_k1["amplitude_fit"]),
+            "expected_lambda": float(theory.lambda_value),
+            "theta_B": float(theta_b),
+            "theta_B_half": float(0.5 * float(theta_b)),
+            "rim_physical_theta_amplitude": float(physical_common_k1["amplitude_fit"]),
+            "rim_physical_theta_amplitude_over_half_theta_B": float(
+                physical_common_k1["amplitude_fit"]
+            )
+            / max(abs(0.5 * float(theta_b)), 1.0e-12),
+            "measured_log_height_slope": float(log_all["slope_fit"]),
+            "expected_log_height_phi_star": float(phi_star),
+            "expected_log_height_slope": float(expected_log_slope),
+            "log_height_slope_ratio": float(log_all["slope_ratio"]),
+        },
+        "log_all": log_all,
+        "log_curvature_filtered": log_clean,
+        "curvature_filtered_shell_count": int(len(clean_log_rows)),
+        "leaflet_sign_convention_probe": _leaflet_sign_convention_probe(
+            shell_rows,
+            radius=radius,
+            lambda_theory=float(theory.lambda_value),
+            last_free_shell_radius=last_free,
+            log_slope_ratio=float(log_all["slope_ratio"]),
+        ),
+    }
+
+
+def _fit_log_channel(
+    rows: list[dict[str, float]],
+    *,
+    radius: float,
+    slope_theory: float,
+) -> dict[str, float | int]:
+    if len(rows) < 2:
+        return {
+            "count": int(len(rows)),
+            "z0_fit": 0.0,
+            "slope_fit": 0.0,
+            "slope_ratio": 0.0,
+            "rel_rmse": 0.0,
+        }
+    r = np.asarray([float(row["radius"]) for row in rows], dtype=float)
+    z = np.asarray([float(row["z"]) for row in rows], dtype=float)
+    z0, slope_fit, _ = _fit_log(r, z, float(radius))
+    zhat = z0 + slope_fit * np.log(r / float(radius))
+    return {
+        "count": int(len(rows)),
+        "z0_fit": float(z0),
+        "slope_fit": float(slope_fit),
+        "slope_ratio": float(slope_fit / max(float(slope_theory), 1.0e-12)),
+        "rel_rmse": _relative_rmse(z, zhat),
+    }
+
+
+def _first_collapse_stage(traces: list[dict[str, object]]) -> dict[str, object]:
+    for trace in traces:
+        candidates = []
+        for row in trace["shells"]:
+            windows = set(row.get("windows", []))
+            if not ({"k1_window", "first_free", "outer_support"} & windows):
+                continue
+            anti = float(row["antisymmetric_gap_abs"])
+            sym = float(row["symmetric_sum_abs"])
+            if anti > 1.0e-7 and sym / max(anti, 1.0e-12) < 0.25:
+                candidates.append(
+                    {
+                        "stage": trace["label"],
+                        "radius": float(row["radius"]),
+                        "windows": sorted(windows),
+                        "theta_in": float(row["theta_in_median"]),
+                        "theta_out": float(row["theta_out_median"]),
+                        "symmetric_sum_abs": sym,
+                        "antisymmetric_gap_abs": anti,
+                    }
+                )
+        if candidates:
+            return candidates[0]
+    return {"stage": "none", "radius": 0.0, "windows": []}
+
+
+def _case_report(*, label: str, theta_b: float, selected: bool) -> dict[str, object]:
+    if selected:
+        schedule = _run_canonical_schedule()
+        mesh = schedule["mesh"]
+        return {
+            "label": label,
+            "theta_B": float(schedule["theta_B_selected"]),
+            "selected_theta": True,
+            "shell_traces": [_shell_trace(mesh, label="selected_theta_final")],
+            "profile_probe": _profile_source_probe(
+                mesh, theta_b=float(schedule["theta_B_selected"])
+            ),
+            "profile_fit_controls": _profile_fit_controls(
+                mesh, theta_b=float(schedule["theta_B_selected"])
+            ),
+        }
+
+    minim = _build_minimizer(float(theta_b), max_iter=10)
+    mesh = minim.mesh
+    traces = [_shell_trace(mesh, label="configured")]
+    minim.enforce_constraints_after_mesh_ops(mesh)
+    traces.append(_shell_trace(mesh, label="after_geometric_enforcement"))
+    minim._relax_leaflet_tilts(
+        positions=mesh.positions_view(),
+        mode=mesh.global_parameters.get("tilt_solve_mode", "fixed"),
+    )
+    traces.append(_shell_trace(mesh, label="after_tilt_relaxation"))
+    gradient_probe = _module_tilt_gradient_probe(minim)
+    perturbations = _perturbation_probes(minim)
+    minim.minimize(n_steps=SHAPE_STEPS)
+    traces.append(_shell_trace(mesh, label="after_shape_minimize"))
+    mesh.project_tilts_to_tangent()
+    mesh.increment_version()
+    traces.append(_shell_trace(mesh, label="after_tangent_projection"))
+    return {
+        "label": label,
+        "theta_B": float(theta_b),
+        "selected_theta": False,
+        "shell_traces": traces,
+        "first_collapse_stage": _first_collapse_stage(traces),
+        "module_tilt_gradient_probe": gradient_probe,
+        "perturbation_probes": perturbations,
+        "profile_probe": _profile_source_probe(mesh, theta_b=float(theta_b)),
+        "profile_fit_controls": _profile_fit_controls(mesh, theta_b=float(theta_b)),
+    }
+
+
+def _classify(report: dict[str, object]) -> str:
+    fixed = report["cases"][0]
+    first = fixed["first_collapse_stage"]
+    stage = str(first.get("stage") or "")
+    profile = fixed["profile_probe"]
+    fit_controls = fixed["profile_fit_controls"]
+    physical_common = fit_controls["primary_physical_common_k1"]
+    gap_ratio = float(profile["window_leaflet_gap_ratio"])
+    log_ratio = abs(float(fit_controls["log_all"]["slope_ratio"]))
+    log_filtered_ratio = abs(
+        float(fit_controls["log_curvature_filtered"]["slope_ratio"])
+    )
+    if _is_good_k1_channel(physical_common) and log_ratio < 0.25:
+        return "outer_tilt_k1_ok_but_log_shape_suppressed"
+    if stage == "after_tilt_relaxation" and gap_ratio > 10.0:
+        return "leaflet_relaxation_drives_antisymmetric_state"
+    if stage == "after_geometric_enforcement":
+        return "support_transition_mask_seeds_leaflet_cancellation"
+    if gap_ratio > 10.0:
+        return "bending_tilt_sign_or_ownership_drives_cancellation"
+    if log_ratio < 0.25 and log_filtered_ratio < 0.25:
+        return "shape_tilt_coupling_missing_after_valid_shape_update"
+    if log_ratio < 0.25 <= log_filtered_ratio:
+        return "far_boundary_or_window_artifact"
+    return "inconclusive"
+
+
+def run_curved_1disk_outer_profile_source_audit(
+    *,
+    theta_b: float = THEORY_THETA_B,
+    include_selected: bool = True,
+) -> dict[str, object]:
+    """Return the outer-profile source audit report."""
+    cases = [
+        _case_report(label="fixed_theory_theta", theta_b=float(theta_b), selected=False)
+    ]
+    if include_selected:
+        cases.append(
+            _case_report(label="selected_theta", theta_b=float(theta_b), selected=True)
+        )
+    report: dict[str, object] = {
+        "theta_B_fixed": float(theta_b),
+        "cases": cases,
+        "diagnosis": {},
+    }
+    classification = _classify(report)
+    report["diagnosis"] = {
+        "classification": classification,
+        "sign_convention_classification": report["cases"][0]["profile_fit_controls"][
+            "leaflet_sign_convention_probe"
+        ]["classification"],
+        "allowed_classifications": sorted(ALLOWED_CLASSIFICATIONS),
+        "allowed_sign_convention_classifications": sorted(
+            SIGN_CONVENTION_CLASSIFICATIONS
+        ),
+        "summary": (
+            "This diagnostic ranks the source of the outer profile mismatch. Any "
+            "runtime or theory-facing change requires a narrow Feature Contract."
+        ),
+        "recommended_next_stream": (
+            "Use the classified source to write a Feature Contract before changing "
+            "bending-tilt signs, ownership, tilt relaxation, support masks, or "
+            "shape/tilt coupling. Do not rescale energy, calibrate coefficients, "
+            "add hidden weights, or tune to the theory curve."
+        ),
+        "no_energy_rescaling": True,
+    }
+    return report
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--theta", type=float, default=THEORY_THETA_B)
+    parser.add_argument(
+        "--skip-selected",
+        action="store_true",
+        help="Only run the fixed-theta case.",
+    )
+    args = parser.parse_args(argv)
+    report = run_curved_1disk_outer_profile_source_audit(
+        theta_b=float(args.theta),
+        include_selected=not bool(args.skip_selected),
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/diagnostics/curved_1disk_rim_inner_tilt_profile_audit.py
+++ b/tools/diagnostics/curved_1disk_rim_inner_tilt_profile_audit.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Audit rim inner-leaflet tilt and outer-profile failures on the curved 1-disk lane.
+
+This diagnostic is read-only with respect to runtime physics.  It traces the
+leaflet radial tilt fields through the existing fixed-theta and selected-theta
+paths, then reports whether the remaining miss is most consistent with a rim
+tilt constraint/projection issue, inner-leaflet ownership, or outer profile
+measurement/coupling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+
+import numpy as np
+
+from modules.energy import bending_tilt_in, bending_tilt_out
+from tools.diagnostics.curved_1disk_shape_propagation_blocker import (
+    _build_minimizer,
+)
+from tools.diagnostics.curved_1disk_shared_rim_phi_target_audit import THEORY_THETA_B
+from tools.diagnostics.curved_1disk_theory_benchmark import (
+    OUTER_K1_WINDOW,
+    OUTER_LOG_WINDOW,
+    SHAPE_STEPS,
+    _fit_outer_k1,
+    _fit_outer_log_height,
+    _outer_curvature_summary,
+    _run_canonical_schedule,
+    _shell_profile,
+)
+from tools.diagnostics.curved_1disk_trumpet_descent_audit import (
+    _breakdown_total,
+    _module_deltas,
+)
+from tools.diagnostics.curved_disk_theory import (
+    compute_curved_disk_theory,
+    tex_reference_params,
+)
+
+RIM_CLASSIFICATIONS = {
+    "inner_leaflet_not_driven",
+    "inner_leaflet_masked_at_rim",
+    "tilt_projection_zeroes_inner_leaflet",
+    "inner_leaflet_energy_prefers_zero",
+    "measurement_uses_wrong_rows",
+    "inconclusive",
+}
+PROFILE_CLASSIFICATIONS = {
+    "leaflet_mismatch_dominates",
+    "shape_slope_not_coupled_to_tilt",
+    "transition_band_still_flattens_profile",
+    "far_boundary_curvature_pollutes_fit",
+    "measurement_window_artifact",
+    "inconclusive",
+}
+
+
+def _row_region(mesh, row: int) -> str:
+    opts = getattr(mesh.vertices[int(mesh.vertex_ids[int(row)])], "options", None) or {}
+    if str(opts.get("preset") or "") == "disk":
+        return "disk"
+    group = str(opts.get("rim_slope_match_group") or "")
+    if group == "rim":
+        return "shared_rim"
+    if group == "outer":
+        return "outer_support"
+    return "outer_free"
+
+
+def _radial_thetas(mesh) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    positions = mesh.positions_view()
+    radii = np.linalg.norm(positions[:, :2], axis=1)
+    r_hat = np.zeros_like(positions)
+    good = radii > 1.0e-12
+    r_hat[good, :2] = positions[good, :2] / radii[good, None]
+    theta_in = np.einsum("ij,ij->i", mesh.tilts_in_view(), r_hat)
+    theta_out = np.einsum("ij,ij->i", mesh.tilts_out_view(), r_hat)
+    return radii, theta_in, theta_out, 0.5 * (theta_in + theta_out)
+
+
+def _field_trace(mesh, *, label: str) -> dict[str, object]:
+    radii, theta_in, theta_out, theta_shared = _radial_thetas(mesh)
+    rows = []
+    for radius in sorted({round(float(r), 8) for r in radii if r > 1.0e-12}):
+        mask = np.isclose(np.round(radii, 8), radius, atol=5.0e-9)
+        regions = sorted({_row_region(mesh, int(row)) for row in np.flatnonzero(mask)})
+        rows.append(
+            {
+                "radius": float(np.median(radii[mask])),
+                "regions": regions,
+                "row_count": int(np.count_nonzero(mask)),
+                "theta_in_median": float(np.median(theta_in[mask])),
+                "theta_out_median": float(np.median(theta_out[mask])),
+                "theta_shared_median": float(np.median(theta_shared[mask])),
+                "theta_in_abs_max": float(np.max(np.abs(theta_in[mask]))),
+                "theta_out_abs_max": float(np.max(np.abs(theta_out[mask]))),
+            }
+        )
+    rim_mask = np.array(
+        [_row_region(mesh, row) == "shared_rim" for row in range(len(radii))]
+    )
+    support_mask = np.array(
+        [_row_region(mesh, row) == "outer_support" for row in range(len(radii))]
+    )
+    return {
+        "label": str(label),
+        "shells": rows,
+        "rim": _region_theta_summary(theta_in, theta_out, theta_shared, rim_mask),
+        "outer_support": _region_theta_summary(
+            theta_in, theta_out, theta_shared, support_mask
+        ),
+    }
+
+
+def _region_theta_summary(
+    theta_in: np.ndarray,
+    theta_out: np.ndarray,
+    theta_shared: np.ndarray,
+    mask: np.ndarray,
+) -> dict[str, float | int]:
+    if not np.any(mask):
+        return {
+            "row_count": 0,
+            "theta_in_median": 0.0,
+            "theta_out_median": 0.0,
+            "theta_shared_median": 0.0,
+            "leaflet_gap_median": 0.0,
+        }
+    return {
+        "row_count": int(np.count_nonzero(mask)),
+        "theta_in_median": float(np.median(theta_in[mask])),
+        "theta_out_median": float(np.median(theta_out[mask])),
+        "theta_shared_median": float(np.median(theta_shared[mask])),
+        "leaflet_gap_median": float(
+            np.median(np.abs(theta_in[mask] - theta_out[mask]))
+        ),
+    }
+
+
+def _tilt_enforce_trace(theta_b: float) -> tuple[object, list[dict[str, object]]]:
+    minim = _build_minimizer(float(theta_b), max_iter=10)
+    mesh = minim.mesh
+    traces = [_field_trace(mesh, label="configured")]
+    minim.enforce_constraints_after_mesh_ops(mesh)
+    traces.append(_field_trace(mesh, label="after_geometric_enforcement"))
+    minim._relax_leaflet_tilts(
+        positions=mesh.positions_view(),
+        mode=mesh.global_parameters.get("tilt_solve_mode", "fixed"),
+    )
+    traces.append(_field_trace(mesh, label="after_tilt_relaxation"))
+    before_in = mesh.tilts_in_view().copy(order="F")
+    before_out = mesh.tilts_out_view().copy(order="F")
+    if hasattr(minim.constraint_manager, "enforce_tilt_constraints"):
+        minim.constraint_manager.enforce_tilt_constraints(
+            mesh, global_params=mesh.global_parameters
+        )
+    traces.append(_field_trace(mesh, label="after_rim_tilt_enforcement"))
+    traces[-1]["tilt_enforcement_delta"] = {
+        "tilt_in_l2": float(np.linalg.norm(mesh.tilts_in_view() - before_in)),
+        "tilt_out_l2": float(np.linalg.norm(mesh.tilts_out_view() - before_out)),
+    }
+    return minim, traces
+
+
+def _module_gradient_probe(minim) -> dict[str, object]:
+    mesh = minim.mesh
+    positions = mesh.positions_view()
+    common = {
+        "mesh": mesh,
+        "global_params": mesh.global_parameters,
+        "param_resolver": minim.param_resolver,
+        "positions": positions,
+        "index_map": mesh.vertex_index_to_row,
+        "ctx": None,
+        "tilts_in": mesh.tilts_in_view(),
+        "tilts_out": mesh.tilts_out_view(),
+    }
+    out: dict[str, object] = {}
+    for name, module, tilt_key in (
+        ("bending_tilt_in", bending_tilt_in, "tilt_in"),
+        ("bending_tilt_out", bending_tilt_out, "tilt_out"),
+    ):
+        grad = np.zeros_like(positions)
+        tin_grad = np.zeros_like(mesh.tilts_in_view())
+        tout_grad = np.zeros_like(mesh.tilts_out_view())
+        energy = module.compute_energy_and_gradient_array(
+            grad_arr=grad,
+            tilt_in_grad_arr=tin_grad,
+            tilt_out_grad_arr=tout_grad,
+            **common,
+        )
+        tilt_grad = tin_grad if tilt_key == "tilt_in" else tout_grad
+        out[name] = {
+            "energy": float(energy),
+            "shape_grad_norm": float(np.linalg.norm(grad)),
+            "shape_grad_z_abs_by_region": _abs_by_region(mesh, grad[:, 2]),
+            "tilt_grad_norm": float(np.linalg.norm(tilt_grad)),
+            "tilt_grad_abs_by_region": _abs_by_region(
+                mesh, np.linalg.norm(tilt_grad, axis=1)
+            ),
+        }
+    return out
+
+
+def _abs_by_region(mesh, values: np.ndarray) -> dict[str, float]:
+    out = {"disk": 0.0, "shared_rim": 0.0, "outer_support": 0.0, "outer_free": 0.0}
+    for row, value in enumerate(np.asarray(values, dtype=float)):
+        out[_row_region(mesh, row)] += abs(float(value))
+    return out
+
+
+def _energy_reconciliation(minim, *, epsilon: float = 1.0e-6) -> dict[str, object]:
+    mesh = minim.mesh
+    positions0 = mesh.positions_view().copy(order="F")
+    baseline = minim.compute_energy_breakdown()
+    radii = np.linalg.norm(positions0[:, :2], axis=1)
+    free = np.array(
+        [_row_region(mesh, row) == "outer_free" for row in range(len(radii))]
+    )
+    mode = np.zeros(len(radii), dtype=float)
+    if np.any(free):
+        r_min = float(np.min(radii[free]))
+        vals = np.log(np.maximum(radii, r_min) / max(r_min, 1.0e-12))
+        scale = float(np.max(np.abs(vals[free])))
+        if scale > 0.0:
+            mode[free] = vals[free] / scale
+    perturbed = positions0.copy(order="F")
+    perturbed[:, 2] += float(epsilon) * mode
+    for row, vid in enumerate(mesh.vertex_ids):
+        mesh.vertices[int(vid)].position[:] = perturbed[row]
+    mesh.increment_version()
+    mesh.build_position_cache()
+    after = minim.compute_energy_breakdown()
+    for row, vid in enumerate(mesh.vertex_ids):
+        mesh.vertices[int(vid)].position[:] = positions0[row]
+    mesh.increment_version()
+    mesh.build_position_cache()
+    deltas = _module_deltas(baseline, after)
+    total_delta = _breakdown_total(after) - _breakdown_total(baseline)
+    module_sum = _breakdown_total(deltas)
+    return {
+        "epsilon": float(epsilon),
+        "total_delta": float(total_delta),
+        "module_delta_sum": float(module_sum),
+        "module_residual": float(total_delta - module_sum),
+        "module_deltas": deltas,
+    }
+
+
+def _profile_source_probe(mesh, *, theta_b: float) -> dict[str, object]:
+    params = tex_reference_params()
+    theory = compute_curved_disk_theory(params)
+    shell_rows = _shell_profile(mesh)
+    radius = float(params.radius)
+    radii = [float(row["radius"]) for row in shell_rows]
+    max_radius = float(max(radii))
+    free_outer_radii = sorted(
+        rr for rr in radii if rr > radius + 1.0e-6 and rr < max_radius - 1.0e-6
+    )
+    last_free = float(free_outer_radii[-1]) if free_outer_radii else max_radius
+    k1_rows = [
+        row
+        for row in shell_rows
+        if OUTER_K1_WINDOW[0] * radius <= float(row["radius"]) <= last_free - 1.0e-6
+        and float(row["radius"]) <= OUTER_K1_WINDOW[1] * radius
+    ]
+    profile = {
+        "outer_k1_shared": _fit_outer_k1(
+            shell_rows,
+            radius=radius,
+            lambda_theory=float(theory.lambda_value),
+            last_free_shell_radius=last_free,
+            window=OUTER_K1_WINDOW,
+        ),
+        "outer_height_log": _fit_outer_log_height(
+            shell_rows,
+            radius=radius,
+            slope_theory=0.5 * float(theta_b) * radius,
+            last_free_shell_radius=last_free,
+            window=OUTER_LOG_WINDOW,
+        ),
+        "outer_curvature": _outer_curvature_summary(
+            shell_rows, radius=radius, last_free_shell_radius=last_free
+        ),
+        "fit_window_shells": [
+            {
+                "radius": float(row["radius"]),
+                "theta_in": float(row["theta_in"]),
+                "theta_out": float(row["theta_out"]),
+                "theta_shared": float(row["theta_shared"]),
+                "z": float(row["z"]),
+                "J": float(row["J"]),
+                "leaflet_gap": float(abs(row["theta_in"] - row["theta_out"])),
+            }
+            for row in k1_rows
+        ],
+    }
+    gaps = [float(row["leaflet_gap"]) for row in profile["fit_window_shells"]]
+    shared = [abs(float(row["theta_shared"])) for row in profile["fit_window_shells"]]
+    profile["window_leaflet_gap_ratio"] = (
+        float(np.median(gaps) / max(np.median(shared), 1.0e-12)) if gaps else 0.0
+    )
+    return profile
+
+
+def _classify_rim(report: dict[str, object]) -> str:
+    fixed = report["cases"][0]
+    traces = fixed["tilt_trace"]
+    after_relax = next(row for row in traces if row["label"] == "after_tilt_relaxation")
+    after_enforce = next(
+        row for row in traces if row["label"] == "after_rim_tilt_enforcement"
+    )
+    rim_relax = after_relax["rim"]
+    rim_enforce = after_enforce["rim"]
+    support_enforce = after_enforce["outer_support"]
+    in_grad = fixed["module_gradient_probe"]["bending_tilt_in"]
+    rim_tilt_grad = float(in_grad["tilt_grad_abs_by_region"]["shared_rim"])
+    enforce_delta = float(after_enforce["tilt_enforcement_delta"]["tilt_in_l2"])
+    theta_in = abs(float(rim_enforce["theta_in_median"]))
+    theta_out = abs(float(rim_enforce["theta_out_median"]))
+    support_theta_in = abs(float(support_enforce["theta_in_median"]))
+    support_theta_out = abs(float(support_enforce["theta_out_median"]))
+    if theta_in > 1.0e-3 and support_theta_in < 1.0e-6 and support_theta_out > 1.0e-3:
+        return "measurement_uses_wrong_rows"
+    if theta_in < 1.0e-6 and theta_out > 1.0e-3 and rim_tilt_grad <= 1.0e-10:
+        return "inner_leaflet_not_driven"
+    if theta_in < 1.0e-6 and float(rim_relax["theta_in_median"]) > 1.0e-4:
+        return "tilt_projection_zeroes_inner_leaflet"
+    if theta_in < 1.0e-6 and enforce_delta > 1.0e-8:
+        return "tilt_projection_zeroes_inner_leaflet"
+    if theta_in < 1.0e-6 and rim_tilt_grad > 1.0e-10:
+        return "inner_leaflet_energy_prefers_zero"
+    return "inconclusive"
+
+
+def _classify_profile(report: dict[str, object]) -> str:
+    fixed = report["cases"][0]
+    profile = fixed["outer_profile_probe"]
+    gap_ratio = float(profile["window_leaflet_gap_ratio"])
+    log_ratio = abs(float(profile["outer_height_log"]["slope_ratio"]))
+    curvature = float(profile["outer_curvature"]["mean_abs_J"])
+    if gap_ratio > 0.5:
+        return "leaflet_mismatch_dominates"
+    if curvature > 0.05:
+        return "far_boundary_curvature_pollutes_fit"
+    if log_ratio < 0.25:
+        return "shape_slope_not_coupled_to_tilt"
+    return "inconclusive"
+
+
+def _case_report(*, label: str, theta_b: float, selected: bool) -> dict[str, object]:
+    if selected:
+        schedule = _run_canonical_schedule()
+        mesh = schedule["mesh"]
+        return {
+            "label": label,
+            "theta_B": float(schedule["theta_B_selected"]),
+            "selected_theta": True,
+            "near_rim": dict(schedule["near_rim"]),
+            "tilt_trace": [_field_trace(mesh, label="selected_theta_final")],
+            "module_gradient_probe": {},
+            "energy_reconciliation": {},
+            "outer_profile_probe": _profile_source_probe(
+                mesh, theta_b=float(schedule["theta_B_selected"])
+            ),
+        }
+
+    minim, traces = _tilt_enforce_trace(float(theta_b))
+    gradient_probe = _module_gradient_probe(minim)
+    reconciliation = _energy_reconciliation(minim)
+    minim.minimize(n_steps=SHAPE_STEPS)
+    traces.append(_field_trace(minim.mesh, label="after_shape_minimize"))
+    return {
+        "label": label,
+        "theta_B": float(theta_b),
+        "selected_theta": False,
+        "tilt_trace": traces,
+        "module_gradient_probe": gradient_probe,
+        "energy_reconciliation": reconciliation,
+        "outer_profile_probe": _profile_source_probe(
+            minim.mesh, theta_b=float(theta_b)
+        ),
+    }
+
+
+def run_curved_1disk_rim_inner_tilt_profile_audit(
+    *,
+    theta_b: float = THEORY_THETA_B,
+    include_selected: bool = True,
+) -> dict[str, object]:
+    """Return a diagnostic report for the remaining rim/profile miss."""
+    cases = [
+        _case_report(label="fixed_theory_theta", theta_b=float(theta_b), selected=False)
+    ]
+    if include_selected:
+        cases.append(
+            _case_report(label="selected_theta", theta_b=float(theta_b), selected=True)
+        )
+    report: dict[str, object] = {
+        "theta_B_fixed": float(theta_b),
+        "cases": cases,
+        "diagnosis": {},
+    }
+    rim_class = _classify_rim(report)
+    profile_class = _classify_profile(report)
+    report["diagnosis"] = {
+        "rim_inner_tilt_classification": rim_class,
+        "outer_profile_classification": profile_class,
+        "allowed_rim_classifications": sorted(RIM_CLASSIFICATIONS),
+        "allowed_profile_classifications": sorted(PROFILE_CLASSIFICATIONS),
+        "recommended_next_stream": (
+            "Write a narrow Feature Contract for the classified blocker before "
+            "changing rim tilt constraints, leaflet ownership, shape/tilt coupling, "
+            "or profile/far-boundary handling. Do not rescale energy or tune coefficients."
+        ),
+        "no_energy_rescaling": True,
+    }
+    return report
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--theta", type=float, default=THEORY_THETA_B)
+    parser.add_argument(
+        "--skip-selected",
+        action="store_true",
+        help="Only run the fixed-theta case.",
+    )
+    args = parser.parse_args(argv)
+    report = run_curved_1disk_rim_inner_tilt_profile_audit(
+        theta_b=float(args.theta),
+        include_selected=not bool(args.skip_selected),
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/diagnostics/curved_1disk_shape_direction_audit.py
+++ b/tools/diagnostics/curved_1disk_shape_direction_audit.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Audit why accepted curved 1-disk shape updates weakly follow the log mode.
+
+This diagnostic is read-only with respect to runtime physics.  It decomposes the
+fixed-theta projected shape gradient into interpretable ``z`` directions and
+probes equal-norm trial steps through the current runtime energy path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+
+import numpy as np
+
+from tools.diagnostics.curved_1disk_shape_propagation_blocker import (
+    _build_minimizer,
+    _restore_state,
+    _shell_stats,
+)
+from tools.diagnostics.curved_1disk_shared_rim_phi_target_audit import THEORY_THETA_B
+from tools.diagnostics.curved_1disk_trumpet_descent_audit import (
+    _apply_z_mode,
+    _breakdown_total,
+    _capture_state,
+    _free_outer_mask,
+    _module_deltas,
+    _outer_modes,
+    _row_region,
+)
+
+DEFAULT_EPSILON = 1.0e-5
+DEFAULT_HORIZONS = (1, 5, 20)
+ALLOWED_CLASSIFICATIONS = {
+    "support_shell_gradient_dominates",
+    "high_frequency_gradient_dominates",
+    "coordinate_metric_misweights_outer_shells",
+    "line_search_rejects_profile_direction",
+    "post_step_tilt_projection_erases_profile_gain",
+    "inconclusive",
+}
+
+
+def _prepare_minimizer(theta_b: float):
+    minim = _build_minimizer(float(theta_b), max_iter=10)
+    mesh = minim.mesh
+    minim.enforce_constraints_after_mesh_ops(mesh)
+    minim._relax_leaflet_tilts(
+        positions=mesh.positions_view(),
+        mode=mesh.global_parameters.get("tilt_solve_mode", "fixed"),
+    )
+    return minim
+
+
+def _projected_shape_gradient(minim) -> tuple[float, np.ndarray]:
+    energy, grad = minim.compute_energy_and_gradient_array()
+    minim.project_constraints_array(grad)
+    minim._project_curved_free_disk_shape_dofs(grad)
+    return float(energy), np.asarray(grad[:, 2], dtype=float).copy()
+
+
+def _unit_l2(values: np.ndarray, *, mask: np.ndarray | None = None) -> np.ndarray:
+    out = np.asarray(values, dtype=float).copy()
+    if mask is not None:
+        out[~np.asarray(mask, dtype=bool)] = 0.0
+    norm = float(np.linalg.norm(out))
+    if norm <= 0.0 or not np.isfinite(norm):
+        return np.zeros_like(out)
+    return out / norm
+
+
+def _radius_labels(mesh) -> np.ndarray:
+    positions = mesh.positions_view()
+    radii = np.linalg.norm(positions[:, :2], axis=1)
+    return np.round(radii, decimals=8)
+
+
+def _shell_median_smooth(mesh, values: np.ndarray) -> np.ndarray:
+    labels = _radius_labels(mesh)
+    smooth = np.zeros_like(values, dtype=float)
+    for radius in sorted(set(float(v) for v in labels)):
+        mask = np.isclose(labels, radius, atol=5.0e-9)
+        smooth[mask] = float(np.median(values[mask]))
+    return smooth
+
+
+def _near_support_mask(mesh) -> np.ndarray:
+    labels = _radius_labels(mesh)
+    free_mask = _free_outer_mask(mesh)
+    support = np.array(
+        [_row_region(mesh, row) == "outer_support" for row in range(len(labels))]
+    )
+    free_radii = sorted({float(v) for v in labels[free_mask]})
+    near_radii = set(free_radii[:4])
+    near_free = np.array([float(v) in near_radii for v in labels], dtype=bool)
+    return support | (free_mask & near_free)
+
+
+def _far_field_mask(mesh) -> np.ndarray:
+    labels = _radius_labels(mesh)
+    free_mask = _free_outer_mask(mesh)
+    free_radii = sorted({float(v) for v in labels[free_mask]})
+    if not free_radii:
+        return np.zeros_like(free_mask)
+    cutoff = free_radii[max(0, int(0.75 * (len(free_radii) - 1)))]
+    return free_mask & (labels >= cutoff)
+
+
+def _row_area_weights(mesh) -> np.ndarray:
+    positions = mesh.positions_view()
+    tri_rows, _ = mesh.triangle_row_cache()
+    weights = np.zeros(len(mesh.vertex_ids), dtype=float)
+    if tri_rows is None or len(tri_rows) == 0:
+        return np.ones(len(mesh.vertex_ids), dtype=float)
+    tri_pos = positions[tri_rows]
+    area = 0.5 * np.linalg.norm(
+        np.cross(
+            tri_pos[:, 1, :] - tri_pos[:, 0, :], tri_pos[:, 2, :] - tri_pos[:, 0, :]
+        ),
+        axis=1,
+    )
+    np.add.at(weights, tri_rows.ravel(), np.repeat(area / 3.0, 3))
+    weights = np.where(weights > 1.0e-14, weights, 1.0)
+    return weights
+
+
+def _direction_catalog(mesh, grad_z: np.ndarray) -> dict[str, np.ndarray]:
+    log_mode = _outer_modes(mesh)["outer_log_trumpet"]
+    descent = -np.asarray(grad_z, dtype=float)
+    log_unit = _unit_l2(log_mode)
+    residual = descent - float(np.dot(descent, log_unit)) * log_unit
+    smooth = _shell_median_smooth(mesh, descent)
+    high_frequency = descent - smooth
+    area_weights = _row_area_weights(mesh)
+    shell_labels = _radius_labels(mesh)
+    shell_counts = np.ones_like(descent)
+    for radius in sorted(set(float(v) for v in shell_labels)):
+        mask = np.isclose(shell_labels, radius, atol=5.0e-9)
+        shell_counts[mask] = float(np.count_nonzero(mask))
+
+    return {
+        "outer_log_trumpet": _unit_l2(log_mode),
+        "projected_gradient_descent": _unit_l2(descent),
+        "log_residual_gradient": _unit_l2(residual),
+        "near_support_gradient": _unit_l2(descent, mask=_near_support_mask(mesh)),
+        "far_field_gradient": _unit_l2(descent, mask=_far_field_mask(mesh)),
+        "high_frequency_gradient": _unit_l2(
+            high_frequency, mask=_free_outer_mask(mesh)
+        ),
+        "area_weighted_gradient_probe": _unit_l2(descent / area_weights),
+        "shell_normalized_gradient_probe": _unit_l2(descent / np.sqrt(shell_counts)),
+        "support_suppressed_gradient_probe": _unit_l2(
+            descent, mask=~_near_support_mask(mesh)
+        ),
+    }
+
+
+def _profile_summary(mesh) -> dict[str, float]:
+    labels = _radius_labels(mesh)
+    free_mask = _free_outer_mask(mesh)
+    if not np.any(free_mask):
+        return {"outer_log_slope": 0.0, "outer_z_span": 0.0, "outer_shell_count": 0}
+    radii: list[float] = []
+    zvals: list[float] = []
+    z = mesh.positions_view()[:, 2]
+    for radius in sorted(set(float(v) for v in labels[free_mask])):
+        mask = free_mask & np.isclose(labels, radius, atol=5.0e-9)
+        radii.append(float(np.median(labels[mask])))
+        zvals.append(float(np.median(z[mask])))
+    r = np.asarray(radii, dtype=float)
+    vals = np.asarray(zvals, dtype=float)
+    if r.size < 2:
+        slope = 0.0
+    else:
+        x = np.log(r / max(float(r[0]), 1.0e-12))
+        slope = float(np.polyfit(x, vals, deg=1)[0])
+    return {
+        "outer_log_slope": slope,
+        "outer_z_span": float(np.max(vals) - np.min(vals)) if vals.size else 0.0,
+        "outer_shell_count": int(vals.size),
+    }
+
+
+def _probe_direction(
+    minim,
+    *,
+    name: str,
+    direction: np.ndarray,
+    baseline: dict[str, float],
+    grad_z: np.ndarray,
+    epsilon: float,
+    relax_tilts: bool,
+) -> dict[str, object]:
+    mesh = minim.mesh
+    state = _capture_state(mesh)
+    _apply_z_mode(mesh, direction, float(epsilon))
+    minim._enforce_constraints()
+    if relax_tilts:
+        minim._relax_leaflet_tilts(
+            positions=mesh.positions_view(),
+            mode=mesh.global_parameters.get("tilt_solve_mode", "fixed"),
+        )
+    profile_after = _profile_summary(mesh)
+    perturbed = minim.compute_energy_breakdown()
+    _restore_state(mesh, *state)
+
+    module_deltas = _module_deltas(baseline, perturbed)
+    total_delta = _breakdown_total(perturbed) - _breakdown_total(baseline)
+    module_delta_sum = _breakdown_total(module_deltas)
+    directional_derivative = float(np.dot(grad_z, direction))
+    armijo_rhs = 1.0e-4 * float(epsilon) * directional_derivative
+    return {
+        "name": str(name),
+        "epsilon": float(epsilon),
+        "relax_tilts": bool(relax_tilts),
+        "direction_norm": float(np.linalg.norm(direction)),
+        "directional_derivative": directional_derivative,
+        "total_delta": float(total_delta),
+        "module_delta_sum": float(module_delta_sum),
+        "module_residual": float(total_delta - module_delta_sum),
+        "armijo_rhs": float(armijo_rhs),
+        "accepted_by_decrease": bool(total_delta <= 0.0),
+        "accepted_by_armijo": bool(total_delta <= armijo_rhs),
+        "profile_after": profile_after,
+        "top_module_deltas": [
+            {"module": str(module), "delta": float(delta)}
+            for module, delta in sorted(
+                module_deltas.items(), key=lambda item: abs(item[1]), reverse=True
+            )[:6]
+        ],
+    }
+
+
+def _direction_summaries(
+    mesh,
+    directions: dict[str, np.ndarray],
+    grad_z: np.ndarray,
+) -> list[dict[str, object]]:
+    log = directions["outer_log_trumpet"]
+    grad_dir = directions["projected_gradient_descent"]
+    rows: list[dict[str, object]] = []
+    for name, direction in directions.items():
+        rows.append(
+            {
+                "name": str(name),
+                "norm": float(np.linalg.norm(direction)),
+                "nonzero_rows": int(np.count_nonzero(np.abs(direction) > 0.0)),
+                "cosine_with_log": float(np.dot(direction, log)),
+                "cosine_with_projected_gradient": float(np.dot(direction, grad_dir)),
+                "gradient_dot_direction": float(np.dot(grad_z, direction)),
+                "abs_by_shell": _shell_stats(mesh, np.abs(direction)),
+            }
+        )
+    return rows
+
+
+def _accepted_update_replay(
+    *,
+    theta_b: float,
+    directions: dict[str, np.ndarray],
+    horizons: Sequence[int],
+) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for horizon in horizons:
+        minim = _prepare_minimizer(float(theta_b))
+        mesh = minim.mesh
+        before = mesh.positions_view().copy(order="F")
+        before_profile = _profile_summary(mesh)
+        before_energy = float(minim.compute_energy())
+        result = minim.minimize(n_steps=int(horizon))
+        after_no_projection = mesh.positions_view().copy(order="F")
+        energy_before_tangent_projection = float(minim.compute_energy())
+        mesh.project_tilts_to_tangent()
+        mesh.increment_version()
+        energy_after_tangent_projection = float(minim.compute_energy())
+        dz = after_no_projection[:, 2] - before[:, 2]
+        dxy = np.linalg.norm(after_no_projection[:, :2] - before[:, :2], axis=1)
+        dz_unit = _unit_l2(dz)
+        rows.append(
+            {
+                "n_steps": int(horizon),
+                "step_success": bool(result["step_success"]),
+                "energy_delta": float(float(result["energy"]) - before_energy),
+                "xy_delta_abs_sum": float(np.sum(np.abs(dxy))),
+                "z_delta_abs_sum": float(np.sum(np.abs(dz))),
+                "profile_before": before_profile,
+                "profile_after": _profile_summary(mesh),
+                "tangent_projection_energy_delta": float(
+                    energy_after_tangent_projection - energy_before_tangent_projection
+                ),
+                "mode_alignment": {
+                    name: {
+                        "cosine": float(np.dot(dz_unit, direction)),
+                        "dot": float(np.dot(dz, direction)),
+                    }
+                    for name, direction in directions.items()
+                },
+                "z_delta_by_shell": _shell_stats(mesh, dz),
+            }
+        )
+    return rows
+
+
+def _classify(report: dict[str, object]) -> str:
+    probes = {
+        row["name"]: row
+        for row in report["directional_probes"]
+        if not bool(row["relax_tilts"])
+    }
+    summaries = {row["name"]: row for row in report["direction_summaries"]}
+    log_probe = probes.get("outer_log_trumpet")
+    if log_probe is not None and not bool(log_probe["accepted_by_decrease"]):
+        return "line_search_rejects_profile_direction"
+
+    replay = report["accepted_update_replay"]
+    if replay:
+        tangent = max(
+            abs(float(row["tangent_projection_energy_delta"])) for row in replay
+        )
+        if tangent > 1.0e-5:
+            return "post_step_tilt_projection_erases_profile_gain"
+        first_align = replay[0]["mode_alignment"]
+        support_cos = abs(float(first_align["near_support_gradient"]["cosine"]))
+        high_cos = abs(float(first_align["high_frequency_gradient"]["cosine"]))
+        log_cos = abs(float(first_align["outer_log_trumpet"]["cosine"]))
+        if support_cos > max(0.5, 3.0 * log_cos):
+            return "support_shell_gradient_dominates"
+        if high_cos > max(0.5, 3.0 * log_cos):
+            return "high_frequency_gradient_dominates"
+
+    base_grad = summaries.get("projected_gradient_descent", {})
+    area_grad = summaries.get("area_weighted_gradient_probe", {})
+    shell_grad = summaries.get("shell_normalized_gradient_probe", {})
+    base_log = abs(float(base_grad.get("cosine_with_log", 0.0)))
+    metric_log = max(
+        abs(float(area_grad.get("cosine_with_log", 0.0))),
+        abs(float(shell_grad.get("cosine_with_log", 0.0))),
+    )
+    if metric_log > max(0.25, 3.0 * base_log):
+        return "coordinate_metric_misweights_outer_shells"
+    return "inconclusive"
+
+
+def run_curved_1disk_shape_direction_audit(
+    *,
+    theta_b: float = THEORY_THETA_B,
+    epsilon: float = DEFAULT_EPSILON,
+    horizons: Sequence[int] = DEFAULT_HORIZONS,
+) -> dict[str, object]:
+    """Return the fixed-theta shape direction source audit report."""
+    minim = _prepare_minimizer(float(theta_b))
+    mesh = minim.mesh
+    baseline = minim.compute_energy_breakdown()
+    gradient_energy, grad_z = _projected_shape_gradient(minim)
+    directions = _direction_catalog(mesh, grad_z)
+    probes = []
+    for name, direction in directions.items():
+        probes.append(
+            _probe_direction(
+                minim,
+                name=name,
+                direction=direction,
+                baseline=baseline,
+                grad_z=grad_z,
+                epsilon=float(epsilon),
+                relax_tilts=False,
+            )
+        )
+        probes.append(
+            _probe_direction(
+                minim,
+                name=name,
+                direction=direction,
+                baseline=baseline,
+                grad_z=grad_z,
+                epsilon=float(epsilon),
+                relax_tilts=True,
+            )
+        )
+
+    report: dict[str, object] = {
+        "theta_B": float(theta_b),
+        "epsilon": float(epsilon),
+        "baseline_energy": {
+            "total": _breakdown_total(baseline),
+            "modules": baseline,
+            "gradient_energy": float(gradient_energy),
+        },
+        "direction_summaries": _direction_summaries(mesh, directions, grad_z),
+        "directional_probes": probes,
+        "accepted_update_replay": _accepted_update_replay(
+            theta_b=float(theta_b),
+            directions=directions,
+            horizons=horizons,
+        ),
+        "diagnosis": {},
+    }
+    classification = _classify(report)
+    report["diagnosis"] = {
+        "classification": classification,
+        "allowed_classifications": sorted(ALLOWED_CLASSIFICATIONS),
+        "summary": (
+            "The audit compares equal-norm shape directions only. Any solver "
+            "preconditioning, projection, line-search, or energy change requires "
+            "a new Feature Contract before implementation."
+        ),
+        "no_energy_rescaling": True,
+        "recommended_next_stream": (
+            "Write a narrow Feature Contract for the classified blocker; do not "
+            "rescale energy, fit coefficients, or add hidden weights."
+        ),
+    }
+    return report
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--theta", type=float, default=THEORY_THETA_B)
+    parser.add_argument("--epsilon", type=float, default=DEFAULT_EPSILON)
+    parser.add_argument(
+        "--horizon",
+        type=int,
+        action="append",
+        dest="horizons",
+        help="Accepted-update replay horizon. May be passed multiple times.",
+    )
+    args = parser.parse_args(argv)
+    horizons = (
+        tuple(int(v) for v in args.horizons) if args.horizons else DEFAULT_HORIZONS
+    )
+    report = run_curved_1disk_shape_direction_audit(
+        theta_b=float(args.theta),
+        epsilon=float(args.epsilon),
+        horizons=horizons,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/diagnostics/curved_1disk_transition_band_ownership_audit.py
+++ b/tools/diagnostics/curved_1disk_transition_band_ownership_audit.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Audit transition-band energy ownership versus shape-gradient ownership.
+
+This diagnostic does not change runtime physics.  It compares the scalar energy
+attributed to the shared-rim support transition band with the projected shape
+gradient that drives accepted curved 1-disk updates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+
+import numpy as np
+
+from tools.diagnostics.curved_1disk_energy_control_volume_audit import (
+    _outer_membrane_tilt_shell_energy,
+)
+from tools.diagnostics.curved_1disk_first_two_shell_ingredient_audit import (
+    _aggregate_row_records,
+    _leaflet_runtime_payload,
+)
+from tools.diagnostics.curved_1disk_shape_direction_audit import (
+    _prepare_minimizer,
+    _radius_labels,
+)
+from tools.diagnostics.curved_1disk_shared_rim_phi_target_audit import THEORY_THETA_B
+from tools.diagnostics.curved_1disk_theory_benchmark import _run_curved_theta_candidate
+from tools.diagnostics.curved_1disk_trumpet_descent_audit import _row_region
+
+THETA_CANDIDATES = (0.06, 0.12, THEORY_THETA_B)
+ALLOWED_CLASSIFICATIONS = {
+    "support_gradient_matches_energy_ownership",
+    "support_gradient_exceeds_energy_ownership",
+    "support_gradient_is_constraint_metric_artifact",
+    "theta_ordering_depends_on_support_energy",
+    "inconclusive",
+}
+
+
+def _transition_rows(mesh) -> np.ndarray:
+    """Return the one-ring transition rows incident to the outer support ring."""
+    support = {
+        int(row)
+        for row in range(len(mesh.vertex_ids))
+        if _row_region(mesh, int(row)) == "outer_support"
+    }
+    if not support:
+        return np.asarray([], dtype=int)
+    tri_rows, _ = mesh.triangle_row_cache()
+    rows = set(support)
+    if tri_rows is not None:
+        for tri in tri_rows:
+            tri_set = {int(row) for row in tri}
+            if support.intersection(tri_set):
+                rows.update(tri_set)
+    return np.asarray(sorted(rows), dtype=int)
+
+
+def _row_masks(mesh) -> dict[str, np.ndarray]:
+    n = len(mesh.vertex_ids)
+    transition = np.zeros(n, dtype=bool)
+    transition[_transition_rows(mesh)] = True
+    support = np.asarray(
+        [_row_region(mesh, row) == "outer_support" for row in range(n)], dtype=bool
+    )
+    labels = _radius_labels(mesh)
+    free = np.asarray([_row_region(mesh, row) == "outer_free" for row in range(n)])
+    return {
+        "transition_band": transition,
+        "outer_support": support,
+        "outer_free": free,
+        "outside_transition": ~transition,
+        "all": np.ones(n, dtype=bool),
+        "radius_labels": labels,
+    }
+
+
+def _project_shape_gradient(minim, grad: np.ndarray) -> np.ndarray:
+    out = np.asarray(grad, dtype=float).copy()
+    minim.project_constraints_array(out)
+    minim._project_curved_free_disk_shape_dofs(out)
+    return out
+
+
+def _module_projected_gradients(minim) -> tuple[dict[str, dict[str, object]], float]:
+    """Return projected shape-gradient rows by runtime module."""
+    positions, index_map, grad_dummy = minim._soa_views()
+    module_rows: dict[str, dict[str, object]] = {}
+    for name, module in zip(minim.energy_module_names, minim.energy_modules):
+        grad = np.zeros_like(positions)
+        energy = minim._call_module_array(
+            module,
+            positions=positions,
+            index_map=index_map,
+            grad_arr=grad,
+        )
+        projected = _project_shape_gradient(minim, grad)
+        module_rows[str(name)] = {
+            "energy": float(energy),
+            "projected_gradient": projected,
+            "projected_gradient_norm": float(np.linalg.norm(projected)),
+        }
+
+    grad_dummy.fill(0.0)
+    _energy, full_grad = minim.compute_energy_and_gradient_array()
+    full_projected = _project_shape_gradient(minim, full_grad)
+    sum_projected = np.sum(
+        [row["projected_gradient"] for row in module_rows.values()], axis=0
+    )
+    residual = float(np.linalg.norm(sum_projected - full_projected))
+    return module_rows, residual
+
+
+def _row_energy_by_module(mesh) -> dict[str, np.ndarray]:
+    """Return approximate local row energy attribution for outer-membrane modules."""
+    n = len(mesh.vertex_ids)
+    out = {
+        "bending_tilt_in": np.zeros(n, dtype=float),
+        "bending_tilt_out": np.zeros(n, dtype=float),
+        "tilt_in": np.zeros(n, dtype=float),
+        "tilt_out": np.zeros(n, dtype=float),
+    }
+    payload_in = _leaflet_runtime_payload(mesh, leaflet="in")
+    payload_out = _leaflet_runtime_payload(mesh, leaflet="out")
+    for row, rec in _aggregate_row_records(mesh, payload_in).items():
+        out["bending_tilt_in"][int(row)] += float(rec["local_contribution_sum"])
+    for row, rec in _aggregate_row_records(mesh, payload_out).items():
+        out["bending_tilt_out"][int(row)] += float(rec["local_contribution_sum"])
+    for row, value in _outer_membrane_tilt_shell_energy(mesh, payload_in).items():
+        out["tilt_in"][int(row)] += float(value)
+    for row, value in _outer_membrane_tilt_shell_energy(mesh, payload_out).items():
+        out["tilt_out"][int(row)] += float(value)
+    return out
+
+
+def _region_gradient_summary(
+    *,
+    mesh,
+    module_gradients: dict[str, dict[str, object]],
+    row_energy: dict[str, np.ndarray],
+) -> dict[str, object]:
+    masks = _row_masks(mesh)
+    transition = masks["transition_band"]
+    area = _row_control_area(mesh)
+    module_rows: list[dict[str, object]] = []
+    total_transition_grad_sq = 0.0
+    total_grad_sq = 0.0
+    total_transition_energy = 0.0
+    total_energy = 0.0
+    for name, payload in module_gradients.items():
+        grad = np.asarray(payload["projected_gradient"], dtype=float)
+        grad_norm_by_row = np.linalg.norm(grad, axis=1)
+        grad_total = float(np.linalg.norm(grad))
+        grad_transition = float(np.linalg.norm(grad[transition]))
+        energy_rows = row_energy.get(str(name), np.zeros(len(mesh.vertex_ids)))
+        energy_total = float(np.sum(energy_rows))
+        energy_transition = float(np.sum(energy_rows[transition]))
+        area_transition = float(np.sum(area[transition]))
+        total_transition_grad_sq += grad_transition**2
+        total_grad_sq += grad_total**2
+        total_transition_energy += energy_transition
+        total_energy += energy_total
+        module_rows.append(
+            {
+                "module": str(name),
+                "energy_total": energy_total,
+                "energy_transition_band": energy_transition,
+                "energy_transition_fraction": _safe_ratio(
+                    abs(energy_transition), abs(energy_total)
+                ),
+                "projected_gradient_norm_total": grad_total,
+                "projected_gradient_norm_transition_band": grad_transition,
+                "gradient_transition_fraction": _safe_ratio(
+                    grad_transition, grad_total
+                ),
+                "gradient_per_abs_energy_transition": _safe_ratio(
+                    grad_transition, abs(energy_transition)
+                ),
+                "gradient_per_area_transition": _safe_ratio(
+                    grad_transition, area_transition
+                ),
+                "top_transition_rows": _top_rows(mesh, grad_norm_by_row, transition),
+            }
+        )
+    return {
+        "modules": sorted(
+            module_rows,
+            key=lambda row: float(row["projected_gradient_norm_transition_band"]),
+            reverse=True,
+        ),
+        "totals": {
+            "energy_total_attributed": float(total_energy),
+            "energy_transition_band_attributed": float(total_transition_energy),
+            "energy_transition_fraction": _safe_ratio(
+                abs(total_transition_energy), abs(total_energy)
+            ),
+            "projected_gradient_norm_total_rss": float(np.sqrt(total_grad_sq)),
+            "projected_gradient_norm_transition_band_rss": float(
+                np.sqrt(total_transition_grad_sq)
+            ),
+            "gradient_transition_fraction": _safe_ratio(
+                float(np.sqrt(total_transition_grad_sq)), float(np.sqrt(total_grad_sq))
+            ),
+        },
+    }
+
+
+def _row_control_area(mesh) -> np.ndarray:
+    positions = mesh.positions_view()
+    tri_rows, _ = mesh.triangle_row_cache()
+    area = np.zeros(len(mesh.vertex_ids), dtype=float)
+    if tri_rows is None or len(tri_rows) == 0:
+        return np.ones(len(mesh.vertex_ids), dtype=float)
+    tri_pos = positions[tri_rows]
+    tri_area = 0.5 * np.linalg.norm(
+        np.cross(
+            tri_pos[:, 1, :] - tri_pos[:, 0, :], tri_pos[:, 2, :] - tri_pos[:, 0, :]
+        ),
+        axis=1,
+    )
+    np.add.at(area, tri_rows.ravel(), np.repeat(tri_area / 3.0, 3))
+    return area
+
+
+def _top_rows(mesh, values: np.ndarray, mask: np.ndarray) -> list[dict[str, object]]:
+    labels = _radius_labels(mesh)
+    rows = []
+    for row in np.flatnonzero(mask):
+        rows.append(
+            {
+                "row": int(row),
+                "region": _row_region(mesh, int(row)),
+                "radius": float(labels[int(row)]),
+                "value": float(values[int(row)]),
+            }
+        )
+    return sorted(rows, key=lambda row: abs(float(row["value"])), reverse=True)[:8]
+
+
+def _safe_ratio(numer: float, denom: float) -> float:
+    if abs(float(denom)) <= 1.0e-14:
+        return 0.0
+    return float(numer) / float(denom)
+
+
+def _theta_candidate_rows(theta_values: Sequence[float]) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for theta in theta_values:
+        result = _run_curved_theta_candidate(float(theta))
+        mesh = result["mesh"]
+        row_energy = _row_energy_by_module(mesh)
+        transition = _row_masks(mesh)["transition_band"]
+        support_energy = {
+            name: float(np.sum(values[transition]))
+            for name, values in row_energy.items()
+        }
+        total_support_energy = float(sum(support_energy.values()))
+        total_energy = float(result["near_rim"]["total_energy"])
+        rows.append(
+            {
+                "theta_B": float(theta),
+                "total_energy": total_energy,
+                "transition_band_energy_by_module": support_energy,
+                "transition_band_energy_total": total_support_energy,
+                "energy_without_transition_band_attributed": float(
+                    total_energy - total_support_energy
+                ),
+            }
+        )
+    rows_sorted = sorted(rows, key=lambda row: float(row["total_energy"]))
+    rows_wo = sorted(
+        rows, key=lambda row: float(row["energy_without_transition_band_attributed"])
+    )
+    for row in rows:
+        row["selected_by_total_energy"] = bool(row is rows_sorted[0])
+        row["selected_without_transition_band_attributed"] = bool(row is rows_wo[0])
+    return rows
+
+
+def _classify(
+    region_summary: dict[str, object],
+    theta_rows: list[dict[str, object]],
+    gradient_residual: float,
+) -> str:
+    totals = region_summary["totals"]
+    grad_fraction = float(totals["gradient_transition_fraction"])
+    energy_fraction = float(totals["energy_transition_fraction"])
+    selected_total = next(
+        row["theta_B"] for row in theta_rows if row["selected_by_total_energy"]
+    )
+    selected_wo = next(
+        row["theta_B"]
+        for row in theta_rows
+        if row["selected_without_transition_band_attributed"]
+    )
+    if gradient_residual > 1.0e-8:
+        return "support_gradient_is_constraint_metric_artifact"
+    if selected_total != selected_wo:
+        return "theta_ordering_depends_on_support_energy"
+    if grad_fraction > max(0.65, 2.0 * energy_fraction):
+        return "support_gradient_exceeds_energy_ownership"
+    if abs(grad_fraction - energy_fraction) <= 0.20:
+        return "support_gradient_matches_energy_ownership"
+    return "inconclusive"
+
+
+def run_curved_1disk_transition_band_ownership_audit(
+    *,
+    theta_b: float = THEORY_THETA_B,
+    theta_values: Sequence[float] = THETA_CANDIDATES,
+) -> dict[str, object]:
+    minim = _prepare_minimizer(float(theta_b))
+    mesh = minim.mesh
+    module_gradients, gradient_residual = _module_projected_gradients(minim)
+    row_energy = _row_energy_by_module(mesh)
+    region_summary = _region_gradient_summary(
+        mesh=mesh,
+        module_gradients=module_gradients,
+        row_energy=row_energy,
+    )
+    theta_rows = _theta_candidate_rows(theta_values)
+    classification = _classify(region_summary, theta_rows, gradient_residual)
+    return {
+        "theta_B": float(theta_b),
+        "transition_band": {
+            "row_count": int(_transition_rows(mesh).size),
+            "row_regions": sorted(
+                {_row_region(mesh, int(row)) for row in _transition_rows(mesh).tolist()}
+            ),
+        },
+        "module_gradient_reconciliation": {
+            "sum_projected_minus_full_norm": float(gradient_residual),
+        },
+        "region_ownership": region_summary,
+        "theta_candidate_ordering": theta_rows,
+        "diagnosis": {
+            "classification": classification,
+            "allowed_classifications": sorted(ALLOWED_CLASSIFICATIONS),
+            "recommendation": _recommendation(classification),
+            "no_energy_rescaling": True,
+        },
+    }
+
+
+def _recommendation(classification: str) -> str:
+    if classification == "support_gradient_exceeds_energy_ownership":
+        return (
+            "Next Feature Contract should target transition-band control-volume "
+            "or shape-gradient ownership using geometry-derived invariants."
+        )
+    if classification == "support_gradient_matches_energy_ownership":
+        return (
+            "Next Feature Contract should target a geometry-derived solver metric "
+            "or preconditioner with benchmark validation."
+        )
+    if classification == "theta_ordering_depends_on_support_energy":
+        return (
+            "Separate support-band scalar energy ownership from shape-step metric "
+            "before changing runtime behavior. Do not freeze the support band."
+        )
+    return (
+        "Collect a narrower transition-band module audit before runtime changes. "
+        "Keep the next stream diagnostic-first."
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--theta", type=float, default=THEORY_THETA_B)
+    args = parser.parse_args(argv)
+    report = run_curved_1disk_transition_band_ownership_audit(theta_b=float(args.theta))
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/diagnostics/curved_1disk_trumpet_descent_audit.py
+++ b/tools/diagnostics/curved_1disk_trumpet_descent_audit.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""Audit whether a small outer trumpet mode is a descent direction.
+
+This diagnostic uses theory theta only as a fixed external drive.  It applies
+small, explicit shape perturbations to free outer-shell ``z`` coordinates and
+measures the current runtime response without changing physics, constraints, or
+solver settings.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+
+import numpy as np
+
+from tools.diagnostics.curved_1disk_shape_propagation_blocker import (
+    _build_minimizer,
+    _restore_state,
+    _shell_stats,
+)
+from tools.diagnostics.curved_1disk_shared_rim_phi_target_audit import THEORY_THETA_B
+
+DEFAULT_EPSILONS = (1.0e-5, 3.0e-5, 1.0e-4)
+ALLOWED_CLASSIFICATIONS = {
+    "trumpet_descent_available",
+    "trumpet_rejected_by_runtime_energy",
+    "trumpet_erased_by_tilt_relaxation",
+    "trumpet_reset_by_constraint_enforcement",
+    "projection_removes_trumpet_gradient",
+    "inconclusive",
+}
+
+
+def _capture_state(mesh) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    return (
+        mesh.positions_view().copy(order="F"),
+        mesh.tilts_view().copy(order="F"),
+        mesh.tilts_in_view().copy(order="F"),
+        mesh.tilts_out_view().copy(order="F"),
+    )
+
+
+def _breakdown_total(breakdown: dict[str, float]) -> float:
+    return float(sum(float(value) for value in breakdown.values()))
+
+
+def _module_deltas(
+    baseline: dict[str, float], perturbed: dict[str, float]
+) -> dict[str, float]:
+    keys = sorted(set(baseline) | set(perturbed))
+    return {
+        key: float(perturbed.get(key, 0.0) - baseline.get(key, 0.0)) for key in keys
+    }
+
+
+def _row_region(mesh, row: int) -> str:
+    opts = getattr(mesh.vertices[int(mesh.vertex_ids[int(row)])], "options", None) or {}
+    if str(opts.get("preset") or "") == "disk":
+        return "disk"
+    group = str(opts.get("rim_slope_match_group") or "")
+    if group == "rim":
+        return "shared_rim"
+    if group == "outer":
+        return "outer_support"
+    return "outer_free"
+
+
+def _free_outer_mask(mesh) -> np.ndarray:
+    mask = np.zeros(len(mesh.vertex_ids), dtype=bool)
+    for row in range(len(mesh.vertex_ids)):
+        mask[row] = _row_region(mesh, row) == "outer_free"
+    if mesh.fixed_mask.shape == mask.shape:
+        mask &= ~mesh.fixed_mask
+    return mask
+
+
+def _normalize_mode(values: np.ndarray, mask: np.ndarray) -> np.ndarray:
+    out = np.zeros_like(values, dtype=float)
+    if not np.any(mask):
+        return out
+    scale = float(np.max(np.abs(values[mask])))
+    if scale <= 0.0 or not np.isfinite(scale):
+        return out
+    out[mask] = values[mask] / scale
+    return out
+
+
+def _outer_modes(mesh) -> dict[str, np.ndarray]:
+    positions = mesh.positions_view()
+    radii = np.linalg.norm(positions[:, :2], axis=1)
+    mask = _free_outer_mask(mesh)
+    modes: dict[str, np.ndarray] = {}
+    if not np.any(mask):
+        return {
+            "outer_log_trumpet": np.zeros(len(mesh.vertex_ids), dtype=float),
+            "outer_log_trumpet_flipped": np.zeros(len(mesh.vertex_ids), dtype=float),
+            "outer_local_shell_bump": np.zeros(len(mesh.vertex_ids), dtype=float),
+        }
+
+    r_min = float(np.min(radii[mask]))
+    log_values = np.log(np.maximum(radii, r_min) / max(r_min, 1.0e-12))
+    log_mode = _normalize_mode(log_values, mask)
+    modes["outer_log_trumpet"] = log_mode
+    modes["outer_log_trumpet_flipped"] = -log_mode
+
+    free_radii = np.asarray(sorted({round(float(r), 8) for r in radii[mask]}))
+    shell = float(free_radii[len(free_radii) // 2])
+    shell_mask = mask & np.isclose(np.round(radii, 8), shell, atol=5.0e-9)
+    bump = np.zeros(len(mesh.vertex_ids), dtype=float)
+    bump[shell_mask] = 1.0
+    modes["outer_local_shell_bump"] = bump
+    return modes
+
+
+def _apply_z_mode(mesh, mode: np.ndarray, amplitude: float) -> None:
+    positions = mesh.positions_view().copy(order="F")
+    positions[:, 2] += float(amplitude) * np.asarray(mode, dtype=float)
+    for row, vid in enumerate(mesh.vertex_ids):
+        mesh.vertices[int(vid)].position[:] = positions[row]
+    mesh.increment_version()
+    mesh.build_position_cache()
+
+
+def _region_delta_by_shell(mesh, mode: np.ndarray) -> list[dict[str, object]]:
+    positions = mesh.positions_view()
+    radii = np.linalg.norm(positions[:, :2], axis=1)
+    rows: list[dict[str, object]] = []
+    for radius in sorted({round(float(r), 8) for r in radii}):
+        shell_mask = np.isclose(np.round(radii, 8), radius, atol=5.0e-9)
+        vals = np.asarray(mode[shell_mask], dtype=float)
+        regions = sorted(
+            {_row_region(mesh, int(row)) for row in np.flatnonzero(shell_mask)}
+        )
+        rows.append(
+            {
+                "radius": float(np.median(radii[shell_mask])),
+                "row_count": int(vals.size),
+                "regions": regions,
+                "mode_abs_sum": float(np.sum(np.abs(vals))),
+                "mode_max_abs": float(np.max(np.abs(vals))) if vals.size else 0.0,
+            }
+        )
+    return rows
+
+
+def _gradient_alignment(minim, mode: np.ndarray) -> dict[str, object]:
+    energy, grad = minim.compute_energy_and_gradient_array()
+    raw = np.array(grad, copy=True)
+    minim.project_constraints_array(grad)
+    minim._project_curved_free_disk_shape_dofs(grad)
+    projected = np.array(grad, copy=True)
+    mode_vec = np.zeros_like(projected)
+    mode_vec[:, 2] = np.asarray(mode, dtype=float)
+    raw_dot = float(np.sum(raw * mode_vec))
+    projected_dot = float(np.sum(projected * mode_vec))
+    return {
+        "energy": float(energy),
+        "raw_dot_mode": raw_dot,
+        "projected_dot_mode": projected_dot,
+        "raw_norm": float(np.linalg.norm(raw)),
+        "projected_norm": float(np.linalg.norm(projected)),
+        "raw_z_by_shell": _shell_stats(minim.mesh, raw[:, 2]),
+        "projected_z_by_shell": _shell_stats(minim.mesh, projected[:, 2]),
+    }
+
+
+def _enforcement_probe(minim, mode: np.ndarray, epsilon: float) -> dict[str, float]:
+    mesh = minim.mesh
+    state = _capture_state(mesh)
+    _apply_z_mode(mesh, mode, float(epsilon))
+    before = mesh.positions_view().copy(order="F")
+    minim._enforce_constraints()
+    after = mesh.positions_view().copy(order="F")
+    _restore_state(mesh, *state)
+    dz_before = before[:, 2] - state[0][:, 2]
+    dz_after = after[:, 2] - state[0][:, 2]
+    dxy_after = np.linalg.norm(after[:, :2] - state[0][:, :2], axis=1)
+    return {
+        "epsilon": float(epsilon),
+        "z_before_abs_sum": float(np.sum(np.abs(dz_before))),
+        "z_after_abs_sum": float(np.sum(np.abs(dz_after))),
+        "z_reset_abs_sum": float(np.sum(np.abs(dz_after - dz_before))),
+        "xy_after_abs_sum": float(np.sum(np.abs(dxy_after))),
+    }
+
+
+def _evaluate_case(
+    minim,
+    *,
+    mode: np.ndarray,
+    epsilon: float,
+    baseline: dict[str, float],
+    relax_tilts: bool,
+) -> dict[str, object]:
+    mesh = minim.mesh
+    state = _capture_state(mesh)
+    _apply_z_mode(mesh, mode, float(epsilon))
+    if relax_tilts:
+        minim._relax_leaflet_tilts(
+            positions=mesh.positions_view(),
+            mode=mesh.global_parameters.get("tilt_solve_mode", "fixed"),
+        )
+    perturbed = minim.compute_energy_breakdown()
+    _restore_state(mesh, *state)
+
+    module_deltas = _module_deltas(baseline, perturbed)
+    total_delta = _breakdown_total(perturbed) - _breakdown_total(baseline)
+    module_delta_sum = _breakdown_total(module_deltas)
+    ranked = sorted(module_deltas.items(), key=lambda item: abs(item[1]), reverse=True)
+    return {
+        "epsilon": float(epsilon),
+        "relax_tilts": bool(relax_tilts),
+        "total_delta": float(total_delta),
+        "module_delta_sum": float(module_delta_sum),
+        "module_residual": float(total_delta - module_delta_sum),
+        "module_deltas": module_deltas,
+        "top_module_deltas": [
+            {"module": str(name), "delta": float(delta)} for name, delta in ranked[:6]
+        ],
+    }
+
+
+def _mode_report(
+    minim,
+    *,
+    name: str,
+    mode: np.ndarray,
+    epsilons: Sequence[float],
+    baseline: dict[str, float],
+) -> dict[str, object]:
+    cases: list[dict[str, object]] = []
+    for epsilon in epsilons:
+        for sign in (1.0, -1.0):
+            signed = float(sign * epsilon)
+            cases.append(
+                _evaluate_case(
+                    minim,
+                    mode=mode,
+                    epsilon=signed,
+                    baseline=baseline,
+                    relax_tilts=False,
+                )
+            )
+            cases.append(
+                _evaluate_case(
+                    minim,
+                    mode=mode,
+                    epsilon=signed,
+                    baseline=baseline,
+                    relax_tilts=True,
+                )
+            )
+    return {
+        "name": str(name),
+        "mode_norm": float(np.linalg.norm(mode)),
+        "mode_max_abs": float(np.max(np.abs(mode))) if mode.size else 0.0,
+        "nonzero_rows": int(np.count_nonzero(np.abs(mode) > 0.0)),
+        "shell_support": _region_delta_by_shell(minim.mesh, mode),
+        "gradient_alignment": _gradient_alignment(minim, mode),
+        "enforcement_probe": _enforcement_probe(
+            minim, mode, float(max(abs(eps) for eps in epsilons))
+        ),
+        "finite_difference_cases": cases,
+    }
+
+
+def _accepted_update_alignment(
+    *,
+    theta_b: float,
+    modes: dict[str, np.ndarray],
+    n_steps_values: Sequence[int] = (1, 5),
+) -> list[dict[str, object]]:
+    """Return accepted minimizer shape-update alignment with probe modes."""
+    rows: list[dict[str, object]] = []
+    for n_steps in n_steps_values:
+        minim = _build_minimizer(float(theta_b), max_iter=10)
+        mesh = minim.mesh
+        minim.enforce_constraints_after_mesh_ops(mesh)
+        minim._relax_leaflet_tilts(
+            positions=mesh.positions_view(),
+            mode=mesh.global_parameters.get("tilt_solve_mode", "fixed"),
+        )
+        before = mesh.positions_view().copy(order="F")
+        before_energy = float(minim.compute_energy())
+        result = minim.minimize(n_steps=int(n_steps))
+        after = mesh.positions_view().copy(order="F")
+        dz = after[:, 2] - before[:, 2]
+        dxy = np.linalg.norm(after[:, :2] - before[:, :2], axis=1)
+        mode_rows: dict[str, dict[str, float]] = {}
+        for name, mode in modes.items():
+            mode = np.asarray(mode, dtype=float)
+            denom = float(np.linalg.norm(dz) * np.linalg.norm(mode))
+            cosine = float(np.dot(dz, mode) / denom) if denom > 0.0 else 0.0
+            mode_rows[str(name)] = {
+                "dot": float(np.dot(dz, mode)),
+                "cosine": cosine,
+            }
+        rows.append(
+            {
+                "n_steps": int(n_steps),
+                "step_success": bool(result["step_success"]),
+                "energy_delta": float(float(result["energy"]) - before_energy),
+                "xy_delta_abs_sum": float(np.sum(np.abs(dxy))),
+                "z_delta_abs_sum": float(np.sum(np.abs(dz))),
+                "mode_alignment": mode_rows,
+                "z_delta_by_shell": _shell_stats(mesh, dz),
+            }
+        )
+    return rows
+
+
+def _case_delta(
+    mode_report: dict[str, object], *, epsilon: float, relax_tilts: bool
+) -> float:
+    for case in mode_report["finite_difference_cases"]:
+        if (
+            case["epsilon"] == float(epsilon)
+            and bool(case["relax_tilts"]) == relax_tilts
+        ):
+            return float(case["total_delta"])
+    return float("nan")
+
+
+def _classify(report: dict[str, object]) -> str:
+    modes = {mode["name"]: mode for mode in report["modes"]}
+    trumpet = modes.get("outer_log_trumpet")
+    flipped = modes.get("outer_log_trumpet_flipped")
+    if trumpet is None or flipped is None:
+        return "inconclusive"
+    eps = float(report["epsilons"][0])
+    enforce = trumpet["enforcement_probe"]
+    if float(enforce["z_reset_abs_sum"]) > 0.25 * max(
+        float(enforce["z_before_abs_sum"]), 1.0e-18
+    ):
+        return "trumpet_reset_by_constraint_enforcement"
+    align = trumpet["gradient_alignment"]
+    raw_dot = abs(float(align["raw_dot_mode"]))
+    projected_dot = abs(float(align["projected_dot_mode"]))
+    if raw_dot > 1.0e-12 and projected_dot < 0.1 * raw_dot:
+        return "projection_removes_trumpet_gradient"
+
+    frozen_pos = _case_delta(trumpet, epsilon=eps, relax_tilts=False)
+    frozen_neg = _case_delta(flipped, epsilon=eps, relax_tilts=False)
+    relaxed_pos = _case_delta(trumpet, epsilon=eps, relax_tilts=True)
+    relaxed_neg = _case_delta(flipped, epsilon=eps, relax_tilts=True)
+    frozen_descent = min(frozen_pos, frozen_neg)
+    relaxed_descent = min(relaxed_pos, relaxed_neg)
+    if frozen_descent < 0.0 and relaxed_descent >= 0.0:
+        return "trumpet_erased_by_tilt_relaxation"
+    if relaxed_descent < 0.0:
+        return "trumpet_descent_available"
+    if frozen_descent >= 0.0 and relaxed_descent >= 0.0:
+        return "trumpet_rejected_by_runtime_energy"
+    return "inconclusive"
+
+
+def _rank_module_responses(report: dict[str, object]) -> list[dict[str, object]]:
+    modes = {mode["name"]: mode for mode in report["modes"]}
+    trumpet = modes.get("outer_log_trumpet")
+    if trumpet is None:
+        return []
+    eps = float(report["epsilons"][0])
+    accum: dict[str, float] = {}
+    for case in trumpet["finite_difference_cases"]:
+        if case["epsilon"] != eps or bool(case["relax_tilts"]):
+            continue
+        for name, delta in case["module_deltas"].items():
+            accum[str(name)] = accum.get(str(name), 0.0) + float(delta)
+    ranked = sorted(accum.items(), key=lambda item: abs(item[1]), reverse=True)
+    return [
+        {
+            "module": str(name),
+            "signed_delta": float(delta),
+            "interpretation": "resists_mode" if float(delta) > 0.0 else "favors_mode",
+        }
+        for name, delta in ranked
+        if abs(float(delta)) > 1.0e-15
+    ][:8]
+
+
+def run_curved_1disk_trumpet_descent_audit(
+    *,
+    theta_b: float = THEORY_THETA_B,
+    epsilons: Sequence[float] = DEFAULT_EPSILONS,
+) -> dict[str, object]:
+    """Return a diagnostic-only trumpet descent audit report."""
+    minim = _build_minimizer(float(theta_b), max_iter=10)
+    mesh = minim.mesh
+    minim.enforce_constraints_after_mesh_ops(mesh)
+    minim._relax_leaflet_tilts(
+        positions=mesh.positions_view(),
+        mode=mesh.global_parameters.get("tilt_solve_mode", "fixed"),
+    )
+    baseline = minim.compute_energy_breakdown()
+    modes = _outer_modes(mesh)
+    report: dict[str, object] = {
+        "theta_B": float(theta_b),
+        "epsilons": [float(eps) for eps in epsilons],
+        "baseline_energy": {
+            "total": _breakdown_total(baseline),
+            "modules": baseline,
+        },
+        "mode_construction": {
+            "outer_free_row_count": int(np.count_nonzero(_free_outer_mask(mesh))),
+            "z_only": True,
+            "amplitude_is_probe_not_parameter": True,
+            "no_energy_rescaling": True,
+        },
+        "modes": [
+            _mode_report(
+                minim,
+                name=name,
+                mode=mode,
+                epsilons=epsilons,
+                baseline=baseline,
+            )
+            for name, mode in modes.items()
+        ],
+        "accepted_update_alignment": _accepted_update_alignment(
+            theta_b=float(theta_b),
+            modes=modes,
+        ),
+        "diagnosis": {},
+    }
+    classification = _classify(report)
+    report["diagnosis"] = {
+        "classification": classification,
+        "allowed_classifications": sorted(ALLOWED_CLASSIFICATIONS),
+        "module_response_rank": _rank_module_responses(report),
+        "recommended_next_stream": (
+            "Write a narrow Feature Contract for the classified blocker before "
+            "changing runtime physics; do not rescale energy or fit coefficients."
+        ),
+    }
+    return report
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--theta", type=float, default=THEORY_THETA_B)
+    parser.add_argument(
+        "--epsilon",
+        type=float,
+        action="append",
+        dest="epsilons",
+        help="Small finite-difference amplitude. May be passed multiple times.",
+    )
+    args = parser.parse_args(argv)
+    epsilons = (
+        tuple(float(eps) for eps in args.epsilons)
+        if args.epsilons
+        else DEFAULT_EPSILONS
+    )
+    report = run_curved_1disk_trumpet_descent_audit(
+        theta_b=float(args.theta), epsilons=epsilons
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds curved 1-disk diagnostics for trumpet descent, shape-direction source, transition-band ownership, rim inner-tilt/profile tracing, and outer-profile sign/shape isolation.
- Adds Feature Contracts documenting the rejected/approved next fix streams around support-gradient and transition-band ownership/regularity.
- Applies the accepted transition-gradient/ownership runtime-scoped fix for shared-rim support-transition handling.
- Updates the known-miss benchmark lock to reflect the current state: physical outer common tilt now fits K1, while log-height shape propagation remains suppressed.

## Motivation / Context
- The curved single-caveolin free-membrane lane still does not fully reproduce `docs/1_disk_3d.tex`.
- Prior diagnostics showed the old shell-2 target issue was fixed, but the remaining miss needed separation between diagnostic sign conventions and real shape propagation/coupling failures.
- The latest audit shows the physical outer common mode is `0.5 * (theta_in - theta_out)` because stored leaflet radial components use opposite local frames. That mode fits K1, while the log trumpet slope remains near zero.

## Design Notes
- Feature contract link/summary:
  - `docs/FEATURE_CONTRACT_CURVED_1DISK_SUPPORT_GRADIENT_FIX.md`
  - `docs/FEATURE_CONTRACT_CURVED_1DISK_TRANSITION_BAND_OWNERSHIP_FIX.md`
  - `docs/FEATURE_CONTRACT_CURVED_1DISK_TRANSITION_GRADIENT_REGULARITY_FIX.md`
- Interfaces changed (if any):
  - No user-facing config or public runtime interface changes.
  - Diagnostic reports gain fields for physical outer common K1 fit, sign-convention probe, shell-wise shape/tilt traces, and transition-band ownership summaries.
- Invariants enforced:
  - No energy rescaling, calibration factors, hidden weights, or theory-fitting knobs.
  - Existing theory reproduction failures remain diagnostic/xfail unless a later Feature Contract approves runtime physics changes.
  - Shape/log-slope follow-up is isolated from leaflet sign-convention diagnosis.

## How to Test
```bash
pytest -q tests/test_curved_1disk_outer_profile_source_audit.py
pytest -q tests/test_curved_1disk_rim_inner_tilt_profile_audit.py tests/test_curved_1disk_outer_profile_source_audit.py
ruff check tools/diagnostics/curved_1disk_outer_profile_source_audit.py tests/test_curved_1disk_outer_profile_source_audit.py
python -m tools.diagnostics.curved_1disk_outer_profile_source_audit
pytest -q -o addopts='' tests/test_curved_1disk_shared_rim_fix_acceptance.py
```
- Local validation run:
  - `pytest -q tests/test_curved_1disk_outer_profile_source_audit.py` -> `6 passed`
  - `pytest -q tests/test_curved_1disk_rim_inner_tilt_profile_audit.py tests/test_curved_1disk_outer_profile_source_audit.py` -> `10 passed`
  - `ruff check tools/diagnostics/curved_1disk_outer_profile_source_audit.py tests/test_curved_1disk_outer_profile_source_audit.py` -> passed
  - `python -m tools.diagnostics.curved_1disk_outer_profile_source_audit` -> passed
  - `pytest -q -o addopts='' tests/test_curved_1disk_shared_rim_fix_acceptance.py` -> `4 passed, 2 xfailed`

## Risks & Mitigations
- Risk: the PR is larger than the nominal review budget because it checkpoints a multi-step accepted diagnostic/fix stream.
  - Mitigation: changes are grouped by diagnostic stream and contract; no unrelated refactors are included.
- Risk: diagnostic sign changes could be mistaken for runtime physics changes.
  - Mitigation: the PR keeps the raw/flip sign-convention probe and explicitly reports `outer_tilt_k1_ok_but_log_shape_suppressed` as the remaining issue.

## Performance / Benchmarks (if relevant)
- No broad performance benchmark was run.
- Targeted benchmark-style diagnostics were run on the exact curved 1-disk lane, including `python -m tools.diagnostics.curved_1disk_outer_profile_source_audit` and shared-rim acceptance tests.

## Assumptions / Open Questions
- Next runtime target is not leaflet relaxation/sign convention; it is the coupling between recovered physical outer tilt and height/log-trumpet propagation, or the height/log-slope diagnostic itself.
- Any runtime/theory-facing fix for that next blocker should be handled under a narrow follow-up Feature Contract.
