### PR TITLE
Refactor: Extract Tilt CG Preconditioner Builders from Minimizer

### DIFF
--- a/runtime/minimizer.py
+++ b/runtime/minimizer.py
@@ -28,6 +28,10 @@ from runtime.minimizer_helpers import (
     get_cached_tilt_fixed_mask,
     restore_diagnostic_state,
 )
+from runtime.preconditioners import (
+    build_leaflet_tilt_cg_preconditioner,
+    build_tilt_cg_preconditioner,
+)
 from runtime.steppers.base import BaseStepper
 from runtime.tilt_projection import (
     build_leaflet_trial_tilts,
@@ -1501,7 +1505,10 @@ class Minimizer:
             else:
                 M_inv = None
                 if preconditioner == "jacobi":
-                    M_inv = self._build_tilt_cg_preconditioner(
+                    M_inv = build_tilt_cg_preconditioner(
+                        self.mesh,
+                        self.param_resolver,
+                        self.energy_context(),
                         positions=positions,
                         index_map=self.mesh.vertex_index_to_row,
                         fixed_mask=fixed_mask,
@@ -1576,123 +1583,6 @@ class Minimizer:
                     rz_old = rz_new
 
         self.mesh.set_tilts_from_array(tilts)
-
-    def _build_tilt_cg_preconditioner(
-        self,
-        *,
-        positions: np.ndarray,
-        index_map: Dict[int, int],
-        fixed_mask: np.ndarray,
-    ) -> np.ndarray:
-        """Return a Jacobi preconditioner for the single-tilt CG solve."""
-        n_vertices = len(self.mesh.vertex_ids)
-        diag = np.zeros(n_vertices, dtype=float)
-
-        k_tilt = float(self.param_resolver.get(None, "tilt_rigidity") or 0.0)
-        if k_tilt != 0.0:
-            tri_rows, _ = self._triangle_rows()
-            if tri_rows is not None and len(tri_rows) > 0:
-                areas = self.energy_context().geometry.triangle_areas(
-                    self.mesh, positions
-                )
-                if areas is not None and len(areas) == len(tri_rows):
-                    vertex_areas = np.zeros(n_vertices, dtype=float)
-                    area_thirds = areas / 3.0
-                    np.add.at(vertex_areas, tri_rows[:, 0], area_thirds)
-                    np.add.at(vertex_areas, tri_rows[:, 1], area_thirds)
-                    np.add.at(vertex_areas, tri_rows[:, 2], area_thirds)
-                    diag += k_tilt * vertex_areas
-
-        k_smooth = float(
-            self.param_resolver.get(None, "tilt_smoothness_rigidity") or 0.0
-        )
-        if k_smooth != 0.0:
-            from geometry.curvature import compute_curvature_data
-
-            _k_vecs, _areas, weights, tri_rows = compute_curvature_data(
-                self.mesh, positions, index_map
-            )
-            if weights is not None and tri_rows is not None and len(tri_rows) > 0:
-                c0 = weights[:, 0]
-                c1 = weights[:, 1]
-                c2 = weights[:, 2]
-                factor = 0.5 * k_smooth
-                np.add.at(diag, tri_rows[:, 0], factor * (c1 + c2))
-                np.add.at(diag, tri_rows[:, 1], factor * (c2 + c0))
-                np.add.at(diag, tri_rows[:, 2], factor * (c0 + c1))
-
-        diag = np.where(diag > 1e-12, diag, 1.0)
-        diag[fixed_mask] = 1.0
-        return 1.0 / diag
-
-    def _build_leaflet_tilt_cg_preconditioner(
-        self,
-        *,
-        positions: np.ndarray,
-        index_map: Dict[int, int],
-        fixed_mask_in: np.ndarray,
-        fixed_mask_out: np.ndarray,
-    ) -> tuple[np.ndarray, np.ndarray]:
-        """Return Jacobi preconditioners for leaflet tilt CG solves."""
-        n_vertices = len(self.mesh.vertex_ids)
-        diag_in = np.zeros(n_vertices, dtype=float)
-        diag_out = np.zeros(n_vertices, dtype=float)
-
-        k_in = float(self.param_resolver.get(None, "tilt_modulus_in") or 0.0)
-        k_out = float(self.param_resolver.get(None, "tilt_modulus_out") or 0.0)
-        if k_in != 0.0 or k_out != 0.0:
-            tri_rows, _ = self._triangle_rows()
-            if tri_rows is not None and len(tri_rows) > 0:
-                areas = self.energy_context().geometry.triangle_areas(
-                    self.mesh, positions
-                )
-                if areas is not None and len(areas) == len(tri_rows):
-                    vertex_areas = np.zeros(n_vertices, dtype=float)
-                    area_thirds = areas / 3.0
-                    np.add.at(vertex_areas, tri_rows[:, 0], area_thirds)
-                    np.add.at(vertex_areas, tri_rows[:, 1], area_thirds)
-                    np.add.at(vertex_areas, tri_rows[:, 2], area_thirds)
-                    if k_in != 0.0:
-                        diag_in += k_in * vertex_areas
-                    if k_out != 0.0:
-                        diag_out += k_out * vertex_areas
-
-        k_smooth_in = float(
-            self.param_resolver.get(None, "bending_modulus_in")
-            or self.param_resolver.get(None, "bending_modulus")
-            or 0.0
-        )
-        k_smooth_out = float(
-            self.param_resolver.get(None, "bending_modulus_out")
-            or self.param_resolver.get(None, "bending_modulus")
-            or 0.0
-        )
-        if k_smooth_in != 0.0 or k_smooth_out != 0.0:
-            from geometry.curvature import compute_curvature_data
-
-            _k_vecs, _areas, weights, tri_rows = compute_curvature_data(
-                self.mesh, positions, index_map
-            )
-            if weights is not None and tri_rows is not None and len(tri_rows) > 0:
-                c0 = weights[:, 0]
-                c1 = weights[:, 1]
-                c2 = weights[:, 2]
-                if k_smooth_in != 0.0:
-                    factor_in = 0.5 * k_smooth_in
-                    np.add.at(diag_in, tri_rows[:, 0], factor_in * (c1 + c2))
-                    np.add.at(diag_in, tri_rows[:, 1], factor_in * (c2 + c0))
-                    np.add.at(diag_in, tri_rows[:, 2], factor_in * (c0 + c1))
-                if k_smooth_out != 0.0:
-                    factor_out = 0.5 * k_smooth_out
-                    np.add.at(diag_out, tri_rows[:, 0], factor_out * (c1 + c2))
-                    np.add.at(diag_out, tri_rows[:, 1], factor_out * (c2 + c0))
-                    np.add.at(diag_out, tri_rows[:, 2], factor_out * (c0 + c1))
-
-        diag_in = np.where(diag_in > 1e-12, diag_in, 1.0)
-        diag_out = np.where(diag_out > 1e-12, diag_out, 1.0)
-        diag_in[fixed_mask_in] = 1.0
-        diag_out[fixed_mask_out] = 1.0
-        return 1.0 / diag_in, 1.0 / diag_out
 
     def _relax_leaflet_tilts(
         self,
@@ -2104,7 +1994,10 @@ class Minimizer:
                     (
                         M_inv_in,
                         M_inv_out,
-                    ) = self._build_leaflet_tilt_cg_preconditioner(
+                    ) = build_leaflet_tilt_cg_preconditioner(
+                        self.mesh,
+                        self.param_resolver,
+                        self.energy_context(),
                         positions=positions,
                         index_map=self.mesh.vertex_index_to_row,
                         fixed_mask_in=fixed_mask_in,

--- a/runtime/preconditioners.py
+++ b/runtime/preconditioners.py
@@ -1,0 +1,129 @@
+"""Jacobi preconditioners for tilt relaxation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from core.parameters.resolver import ParameterResolver
+    from geometry.entities import Mesh
+    from runtime.energy_context import EnergyContext
+
+
+def build_tilt_cg_preconditioner(
+    mesh: Mesh,
+    param_resolver: ParameterResolver,
+    energy_context: EnergyContext,
+    *,
+    positions: np.ndarray,
+    index_map: Dict[int, int],
+    fixed_mask: np.ndarray,
+) -> np.ndarray:
+    """Return a Jacobi preconditioner for the single-tilt CG solve."""
+    n_vertices = len(mesh.vertex_ids)
+    diag = np.zeros(n_vertices, dtype=float)
+
+    k_tilt = float(param_resolver.get(None, "tilt_rigidity") or 0.0)
+    if k_tilt != 0.0:
+        tri_rows, _ = energy_context.geometry.triangle_rows(mesh)
+        if tri_rows is not None and len(tri_rows) > 0:
+            areas = energy_context.geometry.triangle_areas(mesh, positions)
+            if areas is not None and len(areas) == len(tri_rows):
+                vertex_areas = np.zeros(n_vertices, dtype=float)
+                area_thirds = areas / 3.0
+                np.add.at(vertex_areas, tri_rows[:, 0], area_thirds)
+                np.add.at(vertex_areas, tri_rows[:, 1], area_thirds)
+                np.add.at(vertex_areas, tri_rows[:, 2], area_thirds)
+                diag += k_tilt * vertex_areas
+
+    k_smooth = float(param_resolver.get(None, "tilt_smoothness_rigidity") or 0.0)
+    if k_smooth != 0.0:
+        from geometry.curvature import compute_curvature_data
+
+        _k_vecs, _areas, weights, tri_rows = compute_curvature_data(
+            mesh, positions, index_map
+        )
+        if weights is not None and tri_rows is not None and len(tri_rows) > 0:
+            c0 = weights[:, 0]
+            c1 = weights[:, 1]
+            c2 = weights[:, 2]
+            factor = 0.5 * k_smooth
+            np.add.at(diag, tri_rows[:, 0], factor * (c1 + c2))
+            np.add.at(diag, tri_rows[:, 1], factor * (c2 + c0))
+            np.add.at(diag, tri_rows[:, 2], factor * (c0 + c1))
+
+    diag = np.where(diag > 1e-12, diag, 1.0)
+    diag[fixed_mask] = 1.0
+    return 1.0 / diag
+
+
+def build_leaflet_tilt_cg_preconditioner(
+    mesh: Mesh,
+    param_resolver: ParameterResolver,
+    energy_context: EnergyContext,
+    *,
+    positions: np.ndarray,
+    index_map: Dict[int, int],
+    fixed_mask_in: np.ndarray,
+    fixed_mask_out: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return Jacobi preconditioners for leaflet tilt CG solves."""
+    n_vertices = len(mesh.vertex_ids)
+    diag_in = np.zeros(n_vertices, dtype=float)
+    diag_out = np.zeros(n_vertices, dtype=float)
+
+    k_in = float(param_resolver.get(None, "tilt_modulus_in") or 0.0)
+    k_out = float(param_resolver.get(None, "tilt_modulus_out") or 0.0)
+    if k_in != 0.0 or k_out != 0.0:
+        tri_rows, _ = energy_context.geometry.triangle_rows(mesh)
+        if tri_rows is not None and len(tri_rows) > 0:
+            areas = energy_context.geometry.triangle_areas(mesh, positions)
+            if areas is not None and len(areas) == len(tri_rows):
+                vertex_areas = np.zeros(n_vertices, dtype=float)
+                area_thirds = areas / 3.0
+                np.add.at(vertex_areas, tri_rows[:, 0], area_thirds)
+                np.add.at(vertex_areas, tri_rows[:, 1], area_thirds)
+                np.add.at(vertex_areas, tri_rows[:, 2], area_thirds)
+                if k_in != 0.0:
+                    diag_in += k_in * vertex_areas
+                if k_out != 0.0:
+                    diag_out += k_out * vertex_areas
+
+    k_smooth_in = float(
+        param_resolver.get(None, "bending_modulus_in")
+        or param_resolver.get(None, "bending_modulus")
+        or 0.0
+    )
+    k_smooth_out = float(
+        param_resolver.get(None, "bending_modulus_out")
+        or param_resolver.get(None, "bending_modulus")
+        or 0.0
+    )
+    if k_smooth_in != 0.0 or k_smooth_out != 0.0:
+        from geometry.curvature import compute_curvature_data
+
+        _k_vecs, _areas, weights, tri_rows = compute_curvature_data(
+            mesh, positions, index_map
+        )
+        if weights is not None and tri_rows is not None and len(tri_rows) > 0:
+            c0 = weights[:, 0]
+            c1 = weights[:, 1]
+            c2 = weights[:, 2]
+            if k_smooth_in != 0.0:
+                factor_in = 0.5 * k_smooth_in
+                np.add.at(diag_in, tri_rows[:, 0], factor_in * (c1 + c2))
+                np.add.at(diag_in, tri_rows[:, 1], factor_in * (c2 + c0))
+                np.add.at(diag_in, tri_rows[:, 2], factor_in * (c0 + c1))
+            if k_smooth_out != 0.0:
+                factor_out = 0.5 * k_smooth_out
+                np.add.at(diag_out, tri_rows[:, 0], factor_out * (c1 + c2))
+                np.add.at(diag_out, tri_rows[:, 1], factor_out * (c2 + c0))
+                np.add.at(diag_out, tri_rows[:, 2], factor_out * (c0 + c1))
+
+    diag_in = np.where(diag_in > 1e-12, diag_in, 1.0)
+    diag_out = np.where(diag_out > 1e-12, diag_out, 1.0)
+    diag_in[fixed_mask_in] = 1.0
+    diag_out[fixed_mask_out] = 1.0
+    return 1.0 / diag_in, 1.0 / diag_out

--- a/tests/test_preconditioners.py
+++ b/tests/test_preconditioners.py
@@ -1,0 +1,130 @@
+"""Focused unit tests for tilt preconditioner builders."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from core.parameters.global_parameters import GlobalParameters
+from core.parameters.resolver import ParameterResolver
+from geometry.geom_io import parse_geometry
+from runtime.energy_context import EnergyContext
+from runtime.preconditioners import (
+    build_leaflet_tilt_cg_preconditioner,
+    build_tilt_cg_preconditioner,
+)
+
+
+def _build_simple_mesh():
+    """Build a 4-vertex, 2-triangle mesh (a simple square patch)."""
+    # 0---1
+    # | \ |
+    # 3---2
+    data = {
+        "vertices": {
+            0: [0.0, 0.0, 0.0],
+            1: [1.0, 0.0, 0.0],
+            2: [1.0, 1.0, 0.0],
+            3: [0.0, 1.0, 0.0],
+        },
+        "edges": {
+            1: [0, 1],
+            2: [1, 2],
+            3: [2, 3],
+            4: [3, 0],
+            5: [0, 2],
+        },
+        "faces": {
+            0: [1, 2, "r5"],
+            1: [3, 4, -5],
+        },
+        "energy_modules": ["bending_tilt"],
+        "global_parameters": {},
+        "instructions": [],
+    }
+    mesh = parse_geometry(data)
+    return mesh
+
+
+def test_build_tilt_cg_preconditioner_pure_identity():
+    mesh = _build_simple_mesh()
+    params = GlobalParameters()
+    resolver = ParameterResolver(params)
+    context = EnergyContext()
+    context.ensure_for_mesh(mesh)
+
+    positions = mesh.positions_view()
+    index_map = mesh.vertex_index_to_row
+    fixed_mask = np.zeros(len(mesh.vertex_ids), dtype=bool)
+
+    # With no rigidity, should return identity (all ones)
+    M_inv = build_tilt_cg_preconditioner(
+        mesh,
+        resolver,
+        context,
+        positions=positions,
+        index_map=index_map,
+        fixed_mask=fixed_mask,
+    )
+
+    np.testing.assert_allclose(M_inv, 1.0)
+
+
+def test_build_tilt_cg_preconditioner_with_rigidity():
+    mesh = _build_simple_mesh()
+    params = GlobalParameters()
+    params.set("tilt_rigidity", 1.0)
+    resolver = ParameterResolver(params)
+    context = EnergyContext()
+    context.ensure_for_mesh(mesh)
+
+    positions = mesh.positions_view()
+    index_map = mesh.vertex_index_to_row
+    fixed_mask = np.zeros(len(mesh.vertex_ids), dtype=bool)
+
+    M_inv = build_tilt_cg_preconditioner(
+        mesh,
+        resolver,
+        context,
+        positions=positions,
+        index_map=index_map,
+        fixed_mask=fixed_mask,
+    )
+
+    # Jacobi preconditioner is 1/diag.
+    # For small vertex areas, diag < 1.0, so M_inv > 1.0.
+    assert np.all(M_inv >= 1.0)
+    assert not np.allclose(M_inv, 1.0)
+
+
+def test_build_leaflet_tilt_cg_preconditioner_with_rigidity():
+    mesh = _build_simple_mesh()
+    params = GlobalParameters()
+    params.set("tilt_modulus_in", 1.0)
+    params.set("tilt_modulus_out", 2.0)
+    resolver = ParameterResolver(params)
+    context = EnergyContext()
+    context.ensure_for_mesh(mesh)
+
+    positions = mesh.positions_view()
+    index_map = mesh.vertex_index_to_row
+    fixed_mask_in = np.zeros(len(mesh.vertex_ids), dtype=bool)
+    fixed_mask_out = np.zeros(len(mesh.vertex_ids), dtype=bool)
+
+    M_inv_in, M_inv_out = build_leaflet_tilt_cg_preconditioner(
+        mesh,
+        resolver,
+        context,
+        positions=positions,
+        index_map=index_map,
+        fixed_mask_in=fixed_mask_in,
+        fixed_mask_out=fixed_mask_out,
+    )
+
+    # Should be different since moduli are different
+    assert not np.allclose(M_inv_in, M_inv_out)
+
+    # Modulus out is higher (2.0) than in (1.0), so diag_out > diag_in, so M_inv_out < M_inv_in
+    # We only check elements where M_inv_in > 1.0 (i.e. diag > 1e-12)
+    mask = M_inv_in > 1.0
+    assert np.any(mask), f"M_inv_in was {M_inv_in}"
+    np.testing.assert_array_less(M_inv_out[mask], M_inv_in[mask])


### PR DESCRIPTION
## Summary
This PR extracts the tilt Conjugate Gradient (CG) preconditioner builders from the monolithic `Minimizer` class into a dedicated `runtime/preconditioners.py` module. This is a low-risk extraction of pure math helpers to improve maintainability and reduce context weight of `runtime/minimizer.py`.

### Changes
- **Extracted Functions**:
  - `_build_tilt_cg_preconditioner` -> `build_tilt_cg_preconditioner`
  - `_build_leaflet_tilt_cg_preconditioner` -> `build_leaflet_tilt_cg_preconditioner`
- **New Module**: Created `runtime/preconditioners.py` to house these shared helpers.
- **Minimizer Cleanup**: Updated `runtime/minimizer.py` to import and delegate to the new module-level builders.
- **Unit Tests**: Added focused unit tests in `tests/test_preconditioners.py` verifying Jacobi preconditioner construction for both single and dual leaflet modes.

### Validation
- All 25 relevant tests passed, including new focused unit tests and existing tilt relaxation regression tests (`tests/test_tilt_solve_modes.py`, `tests/test_minimizer.py`).
- No changes to physics formulas, constants, or behavior.

### Test Output
```
25 passed in 0.10s
```