### PR TITLE
Extract curved/free-disk shape-gradient projections

### DIFF
--- a/runtime/minimizer.py
+++ b/runtime/minimizer.py
@@ -38,6 +38,7 @@ from runtime.preconditioners import (
     build_leaflet_tilt_cg_preconditioner,
     build_tilt_cg_preconditioner,
 )
+from runtime.projections.curved_disk import project_curved_free_disk_shape_dofs
 from runtime.projections.tilt import (
     build_leaflet_trial_tilts,
     project_leaflet_tilts_with_optional_axisymmetry,
@@ -2208,49 +2209,6 @@ STEP SIZE:\t {self.step_size}
             if getattr(self.mesh.vertices[int(vidx)], "fixed", False):
                 grad_arr[row] = 0.0
 
-    def _project_curved_free_disk_shape_dofs(self, grad_arr: np.ndarray) -> None:
-        """Restrict the shared-rim curved free-disk shape solve to height DOFs."""
-        mode = str(self.global_params.get("rim_slope_match_mode") or "").strip().lower()
-        if mode != "shared_rim_staggered_v1":
-            return
-        if not (
-            self.global_params.get("rim_slope_match_group") is not None
-            and self.global_params.get("rim_slope_match_outer_group") is not None
-            and self.global_params.get("rim_slope_match_disk_group") is not None
-        ):
-            return
-        grad_arr[:, :2] = 0.0
-        self._project_curved_free_disk_transition_shape_metric(grad_arr)
-
-    def _project_curved_free_disk_transition_shape_metric(
-        self, grad_arr: np.ndarray
-    ) -> None:
-        """Remove artificial shared-rim support-transition rows from shape descent."""
-        support_group = str(
-            self.global_params.get("rim_slope_match_outer_group") or ""
-        ).strip()
-        if not support_group:
-            return
-
-        support_rows = np.zeros(len(self.mesh.vertex_ids), dtype=bool)
-        for row, vertex_id in enumerate(self.mesh.vertex_ids):
-            vertex = self.mesh.vertices[int(vertex_id)]
-            if vertex.options.get("rim_slope_match_group") == support_group:
-                support_rows[row] = True
-        if not np.any(support_rows):
-            return
-
-        tri_rows, _ = self.mesh.triangle_row_cache()
-        if tri_rows is None or len(tri_rows) == 0:
-            return
-
-        transition_rows = np.zeros(len(self.mesh.vertex_ids), dtype=bool)
-        transition_tris = np.any(support_rows[np.asarray(tri_rows, dtype=int)], axis=1)
-        transition_rows[np.unique(np.asarray(tri_rows, dtype=int)[transition_tris])] = (
-            True
-        )
-        grad_arr[transition_rows, 2] = 0.0
-
     def _enforce_constraints(self, mesh: Mesh | None = None):
         """Invoke all constraint modules on the current mesh."""
         if not self._has_enforceable_constraints:
@@ -2643,7 +2601,7 @@ STEP SIZE:\t {self.step_size}
             # Use array-based path for main loop
             E, grad_arr = self.compute_energy_and_gradient_array()
             self.project_constraints_array(grad_arr)
-            self._project_curved_free_disk_shape_dofs(grad_arr)
+            project_curved_free_disk_shape_dofs(self.mesh, self.global_params, grad_arr)
             last_grad_arr = grad_arr
 
             if logger.isEnabledFor(logging.DEBUG):

--- a/runtime/projections/curved_disk.py
+++ b/runtime/projections/curved_disk.py
@@ -1,0 +1,54 @@
+"""Specialized shape-gradient projections for curved/free-disk simulations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from core.parameters.global_parameters import GlobalParameters
+    from geometry.entities import Mesh
+
+
+def project_curved_free_disk_shape_dofs(
+    mesh: Mesh, global_params: GlobalParameters, grad_arr: np.ndarray
+) -> None:
+    """Restrict the shared-rim curved free-disk shape solve to height DOFs."""
+    mode = str(global_params.get("rim_slope_match_mode") or "").strip().lower()
+    if mode != "shared_rim_staggered_v1":
+        return
+    if not (
+        global_params.get("rim_slope_match_group") is not None
+        and global_params.get("rim_slope_match_outer_group") is not None
+        and global_params.get("rim_slope_match_disk_group") is not None
+    ):
+        return
+    grad_arr[:, :2] = 0.0
+    _project_curved_free_disk_transition_shape_metric(mesh, global_params, grad_arr)
+
+
+def _project_curved_free_disk_transition_shape_metric(
+    mesh: Mesh, global_params: GlobalParameters, grad_arr: np.ndarray
+) -> None:
+    """Remove artificial shared-rim support-transition rows from shape descent."""
+    support_group = str(global_params.get("rim_slope_match_outer_group") or "").strip()
+    if not support_group:
+        return
+
+    support_rows = np.zeros(len(mesh.vertex_ids), dtype=bool)
+    for row, vertex_id in enumerate(mesh.vertex_ids):
+        vertex = mesh.vertices[int(vertex_id)]
+        if vertex.options.get("rim_slope_match_group") == support_group:
+            support_rows[row] = True
+    if not np.any(support_rows):
+        return
+
+    tri_rows, _ = mesh.triangle_row_cache()
+    if tri_rows is None or len(tri_rows) == 0:
+        return
+
+    transition_rows = np.zeros(len(mesh.vertex_ids), dtype=bool)
+    transition_tris = np.any(support_rows[np.asarray(tri_rows, dtype=int)], axis=1)
+    transition_rows[np.unique(np.asarray(tri_rows, dtype=int)[transition_tris])] = True
+    grad_arr[transition_rows, 2] = 0.0


### PR DESCRIPTION
Summary:
- Move specialized curved/free-disk shape-gradient projection helpers from runtime/minimizer.py to runtime/projections/curved_disk.py.
- Update the minimizer loop to call the module-level projection function.
- Preserve exact call order: projection still happens after project_constraints_array(grad_arr).
- Preserve in-place grad_arr mutation and existing global_params gates.

Behavior:
- No intentional behavior change.
- This is a theory-lane extraction only; standard minimization behavior is unchanged.

Validation:
- tests/test_curved_1disk_shape_propagation_blocker.py
- tests/test_rim_slope_match_out_constraint.py
- tests/test_curved_1disk_first_two_shell_diveval_regression.py
- tests/test_minimizer.py
- tests/test_preconditioners.py
- tests/test_debug_diagnostics_pure.py
- 35 tests passed.