### PR TITLE
refactor: decompose bending_tilt_leaflet.py helpers into bt_params and bt_utils

### DIFF
--- a/modules/energy/bending_tilt_leaflet.py
+++ b/modules/energy/bending_tilt_leaflet.py
@@ -44,6 +44,7 @@ from .bt_params import (
     _use_stage_a_inner_shape_cross_suppression,
     _use_stage_a_outer_grad_linear_transition_operator,
 )
+from .bt_utils import _accumulate_leaflet_tilt_gradient
 
 _BASE_TERM_BOUNDARY_OPTION_KEYS = (
     # Most configs tag the disk interface ring via the rim-slope match group.
@@ -673,33 +674,6 @@ def _inner_bending_tilt_dE_ddiv(
         + (kappa_tri[:, 1] * (base_tri[:, 1] + div_term) * va1_eff)
         + (kappa_tri[:, 2] * (base_tri[:, 2] + div_term) * va2_eff)
     ), stats
-
-
-def _accumulate_leaflet_tilt_gradient(
-    tilt_grad_arr: np.ndarray,
-    tri_rows: np.ndarray,
-    factor: np.ndarray,
-    g0: np.ndarray,
-    g1: np.ndarray,
-    g2: np.ndarray,
-    *,
-    ctx=None,
-    scratch_tag: str,
-) -> None:
-    """Accumulate tilt gradients while reusing scratch buffers when available."""
-    if ctx is None:
-        np.add.at(tilt_grad_arr, tri_rows[:, 0], factor * g0)
-        np.add.at(tilt_grad_arr, tri_rows[:, 1], factor * g1)
-        np.add.at(tilt_grad_arr, tri_rows[:, 2], factor * g2)
-        return
-
-    scaled = ctx.scratch_array(scratch_tag, shape=g0.shape, dtype=g0.dtype)
-    np.multiply(factor, g0, out=scaled)
-    np.add.at(tilt_grad_arr, tri_rows[:, 0], scaled)
-    np.multiply(factor, g1, out=scaled)
-    np.add.at(tilt_grad_arr, tri_rows[:, 1], scaled)
-    np.multiply(factor, g2, out=scaled)
-    np.add.at(tilt_grad_arr, tri_rows[:, 2], scaled)
 
 
 def _inner_recovered_divergence(

--- a/modules/energy/bending_tilt_leaflet.py
+++ b/modules/energy/bending_tilt_leaflet.py
@@ -30,6 +30,21 @@ from modules.energy.leaflet_presence import (
 )
 from modules.energy.scatter import scatter_triangle_scalar_to_vertices
 
+from .bt_params import (
+    _assume_J0_center_xy,
+    _assume_J0_presets,
+    _assume_J0_radius_max,
+    _base_term_boundary_group,
+    _base_term_region_mode,
+    _base_term_region_radius,
+    _bending_tilt_in_update_mode,
+    _per_vertex_params_leaflet,
+    _resolve_bending_modulus,
+    _use_inner_recovered_divergence,
+    _use_stage_a_inner_shape_cross_suppression,
+    _use_stage_a_outer_grad_linear_transition_operator,
+)
+
 _BASE_TERM_BOUNDARY_OPTION_KEYS = (
     # Most configs tag the disk interface ring via the rim-slope match group.
     "rim_slope_match_group",
@@ -39,7 +54,6 @@ _BASE_TERM_BOUNDARY_OPTION_KEYS = (
     "tilt_thetaB_group_out",
 )
 
-_ASSUME_J0_PRESETS_KEY = "bending_tilt_assume_J0_presets"
 _OUTER_TRANSITION_OPERATOR_SHELLS = (
     0.837822,
     0.842474,
@@ -49,148 +63,6 @@ _OUTER_TRANSITION_OPERATOR_SHELLS = (
     0.974541,
     0.999984,
 )
-
-
-def _use_inner_recovered_divergence(global_params, *, cache_tag: str) -> bool:
-    """Return whether recovered inner divergence is enabled for this run.
-
-    Scope the recovered-divergence path to the theory-parity report workflows,
-    which stamp a parity lane onto the mesh/global parameters. This keeps
-    unrelated curved and free-disk solves on the current main behavior.
-    """
-    if str(cache_tag) != "in" or global_params is None:
-        return False
-    return bool(str(global_params.get("theory_parity_lane") or "").strip())
-
-
-def _assume_J0_presets(global_params, *, cache_tag: str) -> tuple[str, ...]:
-    """Optional config: presets for which the Helfrich base term is set to zero.
-
-    This is a theory-mode knob used to match formulations that assume the
-    geometric curvature contribution J (i.e. 2H - c0) vanishes on a tagged
-    patch such as a rigid disk. It is off by default.
-    """
-    if global_params is None:
-        return ()
-    raw = global_params.get(f"{_ASSUME_J0_PRESETS_KEY}_{cache_tag}")
-    if raw is None:
-        raw = global_params.get(_ASSUME_J0_PRESETS_KEY)
-    if raw is None:
-        return ()
-    if isinstance(raw, str):
-        items = [raw]
-    else:
-        try:
-            items = list(raw)
-        except TypeError:
-            items = [raw]
-
-    presets: list[str] = []
-    for item in items:
-        name = str(item).strip()
-        if name:
-            presets.append(name)
-    return tuple(presets)
-
-
-def _assume_J0_radius_max(global_params, *, cache_tag: str) -> float | None:
-    """Optional config: radial cap for theory-mode J0 suppression rows."""
-    if global_params is None:
-        return None
-    raw = global_params.get(f"{_ASSUME_J0_PRESETS_KEY}_radius_max_{cache_tag}")
-    if raw is None:
-        raw = global_params.get(f"{_ASSUME_J0_PRESETS_KEY}_radius_max")
-    if raw is None:
-        return None
-    radius_max = float(raw)
-    if radius_max < 0.0:
-        raise ValueError("bending_tilt_assume_J0_presets_radius_max must be >= 0.")
-    return radius_max
-
-
-def _assume_J0_center_xy(global_params) -> np.ndarray:
-    """Return the xy center used for radial J0-suppression clipping."""
-    if global_params is None:
-        return np.zeros(2, dtype=float)
-    raw = global_params.get("tilt_thetaB_center")
-    if raw is None:
-        raw = global_params.get("pin_to_circle_point")
-    if raw is None:
-        return np.zeros(2, dtype=float)
-    arr = np.asarray(raw, dtype=float).reshape(-1)
-    if arr.size < 2:
-        return np.zeros(2, dtype=float)
-    return arr[:2].astype(float, copy=False)
-
-
-def _base_term_region_mode(global_params) -> str:
-    """Return optional benchmark-scoped base-term region mode."""
-    if global_params is None:
-        return "off"
-    raw = global_params.get("bending_tilt_base_term_region_mode")
-    mode = str(raw or "off").strip().lower()
-    if mode not in {"off", "physical_disk_split_v1", "disk_only_base_term_v1"}:
-        raise ValueError(
-            "bending_tilt_base_term_region_mode must be 'off' or "
-            "'physical_disk_split_v1' or 'disk_only_base_term_v1'."
-        )
-    return mode
-
-
-def _base_term_region_radius(global_params) -> float | None:
-    """Return physical disk radius used by base-term region modes."""
-    if global_params is None:
-        return None
-    raw = global_params.get("bending_tilt_base_term_region_radius")
-    if raw is None:
-        return None
-    radius = float(raw)
-    if radius < 0.0:
-        raise ValueError("bending_tilt_base_term_region_radius must be >= 0.")
-    return radius
-
-
-def _bending_tilt_in_update_mode(global_params) -> str:
-    """Return optional benchmark-scoped inner bending-tilt update mode."""
-    if global_params is None:
-        return "off"
-    raw = global_params.get("bending_tilt_in_update_mode")
-    mode = str(raw or "off").strip().lower()
-    if mode not in {
-        "off",
-        "outer_near_divergence_cap_v1",
-        "radial_cross_term_off_v1",
-    }:
-        raise ValueError(
-            "bending_tilt_in_update_mode must be 'off' or "
-            "'outer_near_divergence_cap_v1' or 'radial_cross_term_off_v1'."
-        )
-    return mode
-
-
-def _use_stage_a_inner_shape_cross_suppression(
-    mesh: Mesh, global_params, *, cache_tag: str
-) -> bool:
-    """Return whether to suppress the inner shape-gradient cross term for Stage A.
-
-    This is intentionally scoped to the Stage A emergent lane only. It changes
-    the *shape-gradient* path of the inner bending-tilt coupling while leaving
-    the scalar energy and tilt-gradient paths unchanged.
-    """
-    if str(cache_tag) != "in" or global_params is None:
-        return False
-    lane = str(global_params.get("theory_parity_lane") or "").strip().lower()
-    return lane == "stage_a_emergent"
-
-
-def _use_stage_a_outer_grad_linear_transition_operator(
-    global_params, *, cache_tag: str
-) -> bool:
-    """Return whether the Stage A outer grad_linear transition operator is enabled."""
-    if str(cache_tag) != "out" or global_params is None:
-        return False
-    lane = str(global_params.get("theory_parity_lane") or "").strip().lower()
-    return lane == "stage_a_emergent"
 
 
 def _outer_transition_operator_payload(
@@ -1145,17 +1017,6 @@ def _base_term_region_zero_rows(
     raise AssertionError("unreachable")
 
 
-def _base_term_boundary_group(global_params, *, cache_tag: str) -> str | None:
-    """Optional config: treat a tagged interface ring as a base-term boundary."""
-    if global_params is None:
-        return None
-    raw = global_params.get(f"bending_tilt_base_term_boundary_group_{cache_tag}")
-    if raw is None:
-        return None
-    group = str(raw).strip()
-    return group if group else None
-
-
 def _interior_mask_leaflet(
     mesh: Mesh,
     global_params,
@@ -1194,102 +1055,6 @@ def _interior_mask_leaflet(
 
     setattr(mesh, cache_attr, {"key": cache_key, "mask": is_interior})
     return is_interior
-
-
-def _resolve_bending_modulus(global_params, kappa_key: str) -> float:
-    """Return the leaflet-specific bending modulus or the global default."""
-    val = global_params.get(kappa_key)
-    if val is None:
-        val = global_params.get("bending_modulus", 0.0)
-    return float(val or 0.0)
-
-
-def _per_vertex_params_leaflet(
-    mesh: Mesh,
-    global_params,
-    *,
-    model: str,
-    kappa_key: str,
-    cache_tag: str,
-) -> tuple[np.ndarray, np.ndarray]:
-    """Return per-vertex (kappa, c0) arrays using a leaflet default modulus."""
-    mesh.build_position_cache()
-
-    n = len(mesh.vertex_ids)
-    kappa_default = _resolve_bending_modulus(global_params, kappa_key)
-
-    # Resolve leaflet-specific spontaneous curvature default
-    c0_key = f"spontaneous_curvature_{cache_tag}"
-    c0_default = global_params.get(c0_key)
-    if c0_default is None:
-        c0_default = (
-            _spontaneous_curvature(global_params) if model == "helfrich" else 0.0
-        )
-    c0_default = float(c0_default or 0.0)
-
-    cache_key = (
-        mesh._vertex_ids_version,
-        model,
-        float(kappa_default),
-        float(c0_default),
-    )
-    cache_attr = f"_bending_leaflet_param_cache_{cache_tag}"
-    cached = getattr(mesh, cache_attr, None)
-    if cached is not None and cached.get("key") == cache_key:
-        return cached["kappa"], cached["c0"]
-
-    kappa = np.full(n, kappa_default, dtype=float)
-    c0 = np.full(n, c0_default, dtype=float)
-
-    override_rows_k: list[int] = []
-    override_vals_k: list[float] = []
-    override_rows_c0: list[int] = []
-    override_vals_c0: list[float] = []
-
-    for vid, vertex in mesh.vertices.items():
-        row = mesh.vertex_index_to_row.get(int(vid))
-        if row is None:
-            continue
-        opts = getattr(vertex, "options", None) or {}
-        if kappa_key in opts:
-            try:
-                override_rows_k.append(row)
-                override_vals_k.append(float(opts[kappa_key]))
-            except (TypeError, ValueError):
-                pass
-        elif "bending_modulus" in opts:
-            try:
-                override_rows_k.append(row)
-                override_vals_k.append(float(opts["bending_modulus"]))
-            except (TypeError, ValueError):
-                pass
-
-        if model == "helfrich":
-            # Per-vertex c0 resolution: leaflet-specific -> generic
-            v_c0 = opts.get(c0_key)
-            if v_c0 is None:
-                v_c0 = opts.get("spontaneous_curvature")
-            if v_c0 is None:
-                v_c0 = opts.get("intrinsic_curvature")
-
-            if v_c0 is not None:
-                try:
-                    override_rows_c0.append(row)
-                    override_vals_c0.append(float(v_c0))
-                except (TypeError, ValueError):
-                    pass
-
-    if override_rows_k:
-        kappa[np.asarray(override_rows_k, dtype=int)] = np.asarray(
-            override_vals_k, dtype=float
-        )
-    if model == "helfrich" and override_rows_c0:
-        c0[np.asarray(override_rows_c0, dtype=int)] = np.asarray(
-            override_vals_c0, dtype=float
-        )
-
-    setattr(mesh, cache_attr, {"key": cache_key, "kappa": kappa, "c0": c0})
-    return kappa, c0
 
 
 def _shared_rim_support_transition_triangle_mask(

--- a/modules/energy/bt_params.py
+++ b/modules/energy/bt_params.py
@@ -1,0 +1,244 @@
+"""Parameter and config helpers for leaflet-specific bending-tilt coupling."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from geometry.entities import Mesh
+from modules.energy.bending import _spontaneous_curvature
+
+_ASSUME_J0_PRESETS_KEY = "bending_tilt_assume_J0_presets"
+
+
+def _use_inner_recovered_divergence(global_params, *, cache_tag: str) -> bool:
+    """Return whether recovered inner divergence is enabled for this run."""
+    if str(cache_tag) != "in" or global_params is None:
+        return False
+    return bool(str(global_params.get("theory_parity_lane") or "").strip())
+
+
+def _assume_J0_presets(global_params, *, cache_tag: str) -> tuple[str, ...]:
+    """Optional config: presets for which the Helfrich base term is set to zero."""
+    if global_params is None:
+        return ()
+    raw = global_params.get(f"{_ASSUME_J0_PRESETS_KEY}_{cache_tag}")
+    if raw is None:
+        raw = global_params.get(_ASSUME_J0_PRESETS_KEY)
+    if raw is None:
+        return ()
+    if isinstance(raw, str):
+        items = [raw]
+    else:
+        try:
+            items = list(raw)
+        except TypeError:
+            items = [raw]
+
+    presets: list[str] = []
+    for item in items:
+        name = str(item).strip()
+        if name:
+            presets.append(name)
+    return tuple(presets)
+
+
+def _assume_J0_radius_max(global_params, *, cache_tag: str) -> float | None:
+    """Optional config: radial cap for theory-mode J0 suppression rows."""
+    if global_params is None:
+        return None
+    raw = global_params.get(f"{_ASSUME_J0_PRESETS_KEY}_radius_max_{cache_tag}")
+    if raw is None:
+        raw = global_params.get(f"{_ASSUME_J0_PRESETS_KEY}_radius_max")
+    if raw is None:
+        return None
+    radius_max = float(raw)
+    if radius_max < 0.0:
+        raise ValueError("bending_tilt_assume_J0_presets_radius_max must be >= 0.")
+    return radius_max
+
+
+def _assume_J0_center_xy(global_params) -> np.ndarray:
+    """Return the xy center used for radial J0-suppression clipping."""
+    if global_params is None:
+        return np.zeros(2, dtype=float)
+    raw = global_params.get("tilt_thetaB_center")
+    if raw is None:
+        raw = global_params.get("pin_to_circle_point")
+    if raw is None:
+        return np.zeros(2, dtype=float)
+    arr = np.asarray(raw, dtype=float).reshape(-1)
+    if arr.size < 2:
+        return np.zeros(2, dtype=float)
+    return arr[:2].astype(float, copy=False)
+
+
+def _base_term_region_mode(global_params) -> str:
+    """Return optional benchmark-scoped base-term region mode."""
+    if global_params is None:
+        return "off"
+    raw = global_params.get("bending_tilt_base_term_region_mode")
+    mode = str(raw or "off").strip().lower()
+    if mode not in {"off", "physical_disk_split_v1", "disk_only_base_term_v1"}:
+        raise ValueError(
+            "bending_tilt_base_term_region_mode must be 'off' or "
+            "'physical_disk_split_v1' or 'disk_only_base_term_v1'."
+        )
+    return mode
+
+
+def _base_term_region_radius(global_params) -> float | None:
+    """Return physical disk radius used by base-term region modes."""
+    if global_params is None:
+        return None
+    raw = global_params.get("bending_tilt_base_term_region_radius")
+    if raw is None:
+        return None
+    radius = float(raw)
+    if radius < 0.0:
+        raise ValueError("bending_tilt_base_term_region_radius must be >= 0.")
+    return radius
+
+
+def _bending_tilt_in_update_mode(global_params) -> str:
+    """Return optional benchmark-scoped inner bending-tilt update mode."""
+    if global_params is None:
+        return "off"
+    raw = global_params.get("bending_tilt_in_update_mode")
+    mode = str(raw or "off").strip().lower()
+    if mode not in {
+        "off",
+        "outer_near_divergence_cap_v1",
+        "radial_cross_term_off_v1",
+    }:
+        raise ValueError(
+            "bending_tilt_in_update_mode must be 'off' or "
+            "'outer_near_divergence_cap_v1' or 'radial_cross_term_off_v1'."
+        )
+    return mode
+
+
+def _use_stage_a_inner_shape_cross_suppression(
+    mesh: Mesh, global_params, *, cache_tag: str
+) -> bool:
+    """Return whether to suppress the inner shape-gradient cross term for Stage A."""
+    if str(cache_tag) != "in" or global_params is None:
+        return False
+    lane = str(global_params.get("theory_parity_lane") or "").strip().lower()
+    return lane == "stage_a_emergent"
+
+
+def _use_stage_a_outer_grad_linear_transition_operator(
+    global_params, *, cache_tag: str
+) -> bool:
+    """Return whether the Stage A outer grad_linear transition operator is enabled."""
+    if str(cache_tag) != "out" or global_params is None:
+        return False
+    lane = str(global_params.get("theory_parity_lane") or "").strip().lower()
+    return lane == "stage_a_emergent"
+
+
+def _base_term_boundary_group(global_params, *, cache_tag: str) -> str | None:
+    """Optional config: treat a tagged interface ring as a base-term boundary."""
+    if global_params is None:
+        return None
+    raw = global_params.get(f"bending_tilt_base_term_boundary_group_{cache_tag}")
+    if raw is None:
+        return None
+    group = str(raw).strip()
+    return group if group else None
+
+
+def _resolve_bending_modulus(global_params, kappa_key: str) -> float:
+    """Return the leaflet-specific bending modulus or the global default."""
+    val = global_params.get(kappa_key)
+    if val is None:
+        val = global_params.get("bending_modulus", 0.0)
+    return float(val or 0.0)
+
+
+def _per_vertex_params_leaflet(
+    mesh: Mesh,
+    global_params,
+    *,
+    model: str,
+    kappa_key: str,
+    cache_tag: str,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return per-vertex (kappa, c0) arrays using a leaflet default modulus."""
+    mesh.build_position_cache()
+
+    n = len(mesh.vertex_ids)
+    kappa_default = _resolve_bending_modulus(global_params, kappa_key)
+
+    # Resolve leaflet-specific spontaneous curvature default
+    c0_key = f"spontaneous_curvature_{cache_tag}"
+    c0_default = global_params.get(c0_key)
+    if c0_default is None:
+        c0_default = (
+            _spontaneous_curvature(global_params) if model == "helfrich" else 0.0
+        )
+    c0_default = float(c0_default or 0.0)
+
+    cache_key = (
+        mesh._vertex_ids_version,
+        model,
+        float(kappa_default),
+        float(c0_default),
+    )
+    cache_attr = f"_bending_leaflet_param_cache_{cache_tag}"
+    cached = getattr(mesh, cache_attr, None)
+    if cached is not None and cached.get("key") == cache_key:
+        return cached["kappa"], cached["c0"]
+
+    kappa = np.full(n, kappa_default, dtype=float)
+    c0 = np.full(n, c0_default, dtype=float)
+
+    override_rows_k: list[int] = []
+    override_vals_k: list[float] = []
+    override_rows_c0: list[int] = []
+    override_vals_c0: list[float] = []
+
+    for vid, vertex in mesh.vertices.items():
+        row = mesh.vertex_index_to_row.get(int(vid))
+        if row is None:
+            continue
+        opts = getattr(vertex, "options", None) or {}
+        if kappa_key in opts:
+            try:
+                override_rows_k.append(row)
+                override_vals_k.append(float(opts[kappa_key]))
+            except (TypeError, ValueError):
+                pass
+        elif "bending_modulus" in opts:
+            try:
+                override_rows_k.append(row)
+                override_vals_k.append(float(opts["bending_modulus"]))
+            except (TypeError, ValueError):
+                pass
+
+        if model == "helfrich":
+            # Per-vertex c0 resolution: leaflet-specific -> generic
+            v_c0 = opts.get(c0_key)
+            if v_c0 is None:
+                v_c0 = opts.get("spontaneous_curvature")
+            if v_c0 is None:
+                v_c0 = opts.get("intrinsic_curvature")
+
+            if v_c0 is not None:
+                try:
+                    override_rows_c0.append(row)
+                    override_vals_c0.append(float(v_c0))
+                except (TypeError, ValueError):
+                    pass
+
+    if override_rows_k:
+        kappa[np.asarray(override_rows_k, dtype=int)] = np.asarray(
+            override_vals_k, dtype=float
+        )
+    if model == "helfrich" and override_rows_c0:
+        c0[np.asarray(override_rows_c0, dtype=int)] = np.asarray(
+            override_vals_c0, dtype=float
+        )
+
+    setattr(mesh, cache_attr, {"key": cache_key, "kappa": kappa, "c0": c0})
+    return kappa, c0

--- a/modules/energy/bt_utils.py
+++ b/modules/energy/bt_utils.py
@@ -1,0 +1,32 @@
+"""Numerical utilities for leaflet-specific bending-tilt coupling."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _accumulate_leaflet_tilt_gradient(
+    tilt_grad_arr: np.ndarray,
+    tri_rows: np.ndarray,
+    factor: np.ndarray,
+    g0: np.ndarray,
+    g1: np.ndarray,
+    g2: np.ndarray,
+    *,
+    ctx=None,
+    scratch_tag: str,
+) -> None:
+    """Accumulate tilt gradients while reusing scratch buffers when available."""
+    if ctx is None:
+        np.add.at(tilt_grad_arr, tri_rows[:, 0], factor * g0)
+        np.add.at(tilt_grad_arr, tri_rows[:, 1], factor * g1)
+        np.add.at(tilt_grad_arr, tri_rows[:, 2], factor * g2)
+        return
+
+    scaled = ctx.scratch_array(scratch_tag, shape=g0.shape, dtype=g0.dtype)
+    np.multiply(factor, g0, out=scaled)
+    np.add.at(tilt_grad_arr, tri_rows[:, 0], scaled)
+    np.multiply(factor, g1, out=scaled)
+    np.add.at(tilt_grad_arr, tri_rows[:, 1], scaled)
+    np.multiply(factor, g2, out=scaled)
+    np.add.at(tilt_grad_arr, tri_rows[:, 2], scaled)


### PR DESCRIPTION
This PR extracts low-risk configuration, parameter resolution, and numerical utility logic from `bending_tilt_leaflet.py` into specialized modules. This is part of an ongoing effort to reduce the context size of the core physics module by moving non-core helper logic.

**Key Changes:**
- **`modules/energy/bt_params.py`**: Centralizes 12 parameter resolution and configuration flags.
- **`modules/energy/bt_utils.py`**: Extracts `_accumulate_leaflet_tilt_gradient`.
- **`modules/energy/bending_tilt_leaflet.py`**: Updated to import helpers from the new modules.

**Testing:**
- Verified with comprehensive test suite (24 tests passed).
- `ruff` linting and formatting applied.