### PR TITLE
fix: stabilize PR527 regressions

### DIFF
--- a/geometry/curvature.py
+++ b/geometry/curvature.py
@@ -157,21 +157,25 @@ def compute_curvature_data(
                 raise TypeError(
                     "Fortran tilt kernels require float64 positions and int32 tri_rows."
                 )
-            kernel_spec = None
-        else:
+        if kernel_spec is not None:
             if kernel_spec.expects_transpose:
                 ok = (
-                    positions.T.flags["F_CONTIGUOUS"]
+                    positions.dtype == np.float64
+                    and tri_rows.dtype == np.int32
+                    and positions.T.flags["F_CONTIGUOUS"]
                     and tri_rows.T.flags["F_CONTIGUOUS"]
                 )
             else:
-                ok = positions.flags["F_CONTIGUOUS"] and tri_rows.flags["F_CONTIGUOUS"]
-            if not ok:
-                if strict:
-                    raise ValueError(
-                        "Fortran tilt kernels require F-contiguous positions/tri_rows (to avoid hidden copies)."
-                    )
-                kernel_spec = None
+                ok = (
+                    positions.dtype == np.float64
+                    and tri_rows.dtype == np.int32
+                    and positions.flags["F_CONTIGUOUS"]
+                    and tri_rows.flags["F_CONTIGUOUS"]
+                )
+            if strict and not ok:
+                raise ValueError(
+                    "Fortran tilt kernels require F-contiguous positions/tri_rows (to avoid hidden copies)."
+                )
 
     if kernel_spec is not None:
         nf = tri_rows.shape[0]
@@ -179,8 +183,16 @@ def compute_curvature_data(
         va1 = np.zeros(nf, dtype=np.float64, order="F")
         va2 = np.zeros(nf, dtype=np.float64, order="F")
         if kernel_spec.expects_transpose:
-            pos_t = positions.T
-            tri_t = tri_rows.T
+            pos_t = (
+                positions.T
+                if positions.dtype == np.float64 and positions.T.flags["F_CONTIGUOUS"]
+                else np.asfortranarray(positions.T, dtype=np.float64)
+            )
+            tri_t = (
+                tri_rows.T
+                if tri_rows.dtype == np.int32 and tri_rows.T.flags["F_CONTIGUOUS"]
+                else np.asfortranarray(tri_rows.T, dtype=np.int32)
+            )
             k_vecs = np.zeros((3, n_verts), dtype=np.float64, order="F")
             vertex_areas = np.zeros(n_verts, dtype=np.float64, order="F")
             weights = np.zeros((3, nf), dtype=np.float64, order="F")
@@ -200,13 +212,23 @@ def compute_curvature_data(
             vertex_areas = np.asarray(vertex_areas)
             weights = np.asarray(weights).T
         else:
+            pos_arg = (
+                positions
+                if positions.dtype == np.float64 and positions.flags["F_CONTIGUOUS"]
+                else np.asfortranarray(positions, dtype=np.float64)
+            )
+            tri_arg = (
+                tri_rows
+                if tri_rows.dtype == np.int32 and tri_rows.flags["F_CONTIGUOUS"]
+                else np.asfortranarray(tri_rows, dtype=np.int32)
+            )
             k_vecs = np.zeros((n_verts, 3), dtype=np.float64, order="F")
             vertex_areas = np.zeros(n_verts, dtype=np.float64, order="F")
             weights = np.zeros((nf, 3), dtype=np.float64, order="F")
             has_optional_areas = _call_fortran_curvature_kernel(
                 kernel_spec.func,
-                positions=positions,
-                tri_rows=tri_rows,
+                positions=pos_arg,
+                tri_rows=tri_arg,
                 k_vecs=k_vecs,
                 vertex_areas=vertex_areas,
                 weights=weights,

--- a/modules/energy/bending_math.py
+++ b/modules/energy/bending_math.py
@@ -36,43 +36,76 @@ def _apply_beltrami_laplacian(
                 raise TypeError(
                     "Fortran bending kernels require float64 weights/field and int32 tri_rows."
                 )
-            kernel_spec = None
-        else:
+        if kernel_spec is not None:
             if kernel_spec.expects_transpose:
                 ok = (
-                    weights.T.flags["F_CONTIGUOUS"]
+                    weights.dtype == np.float64
+                    and tri_rows.dtype == np.int32
+                    and field.dtype == np.float64
+                    and weights.T.flags["F_CONTIGUOUS"]
                     and tri_rows.T.flags["F_CONTIGUOUS"]
                     and field.T.flags["F_CONTIGUOUS"]
                 )
             else:
                 ok = (
-                    weights.flags["F_CONTIGUOUS"]
+                    weights.dtype == np.float64
+                    and tri_rows.dtype == np.int32
+                    and field.dtype == np.float64
+                    and weights.flags["F_CONTIGUOUS"]
                     and tri_rows.flags["F_CONTIGUOUS"]
                     and field.flags["F_CONTIGUOUS"]
                 )
-            if not ok:
-                if strict:
-                    raise ValueError(
-                        "Fortran bending kernels require F-contiguous weights/tri_rows/field (to avoid hidden copies)."
-                    )
-                kernel_spec = None
+            if strict and not ok:
+                raise ValueError(
+                    "Fortran bending kernels require F-contiguous weights/tri_rows/field (to avoid hidden copies)."
+                )
 
     if kernel_spec is not None:
         if kernel_spec.expects_transpose:
+            weights_t = (
+                weights.T
+                if weights.dtype == np.float64 and weights.T.flags["F_CONTIGUOUS"]
+                else np.asfortranarray(weights.T, dtype=np.float64)
+            )
+            tri_t = (
+                tri_rows.T
+                if tri_rows.dtype == np.int32 and tri_rows.T.flags["F_CONTIGUOUS"]
+                else np.asfortranarray(tri_rows.T, dtype=np.int32)
+            )
+            field_t = (
+                field.T
+                if field.dtype == np.float64 and field.T.flags["F_CONTIGUOUS"]
+                else np.asfortranarray(field.T, dtype=np.float64)
+            )
             try:
-                out_t = np.empty_like(field.T, order="F")
-                kernel_spec.func(weights.T, tri_rows.T, field.T, out_t, 1)
+                out_t = np.empty_like(field_t, order="F")
+                kernel_spec.func(weights_t, tri_t, field_t, out_t, 1)
                 return out_t.T
             except TypeError:
-                out_t = kernel_spec.func(weights.T, tri_rows.T, field.T, 1)
+                out_t = kernel_spec.func(weights_t, tri_t, field_t, 1)
                 return np.asarray(out_t).T
 
+        weights_arg = (
+            weights
+            if weights.dtype == np.float64 and weights.flags["F_CONTIGUOUS"]
+            else np.asfortranarray(weights, dtype=np.float64)
+        )
+        tri_arg = (
+            tri_rows
+            if tri_rows.dtype == np.int32 and tri_rows.flags["F_CONTIGUOUS"]
+            else np.asfortranarray(tri_rows, dtype=np.int32)
+        )
+        field_arg = (
+            field
+            if field.dtype == np.float64 and field.flags["F_CONTIGUOUS"]
+            else np.asfortranarray(field, dtype=np.float64)
+        )
         try:
-            out = np.empty_like(field, order="F")
-            kernel_spec.func(weights, tri_rows, field, out, 1)
+            out = np.empty_like(field_arg, order="F")
+            kernel_spec.func(weights_arg, tri_arg, field_arg, out, 1)
             return out
         except Exception:
-            out = kernel_spec.func(weights, tri_rows, field, 1)
+            out = kernel_spec.func(weights_arg, tri_arg, field_arg, 1)
             return np.asarray(out)
 
     c0, c1, c2 = weights[:, 0], weights[:, 1], weights[:, 2]
@@ -95,37 +128,60 @@ def _grad_cotan(u: np.ndarray, v: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     if u.dtype != np.float64 or v.dtype != np.float64:
         if strict:
             raise TypeError("Fortran bending kernels require float64 u/v.")
-        return _grad_cotan_numpy(u, v)
+        u_arg = np.asfortranarray(u, dtype=np.float64)
+        v_arg = np.asfortranarray(v, dtype=np.float64)
+    else:
+        u_arg = u
+        v_arg = v
 
     if kernel_spec.expects_transpose:
-        ok = u.T.flags["F_CONTIGUOUS"] and v.T.flags["F_CONTIGUOUS"]
+        ok = u_arg.T.flags["F_CONTIGUOUS"] and v_arg.T.flags["F_CONTIGUOUS"]
     else:
-        ok = u.flags["F_CONTIGUOUS"] and v.flags["F_CONTIGUOUS"]
+        ok = u_arg.flags["F_CONTIGUOUS"] and v_arg.flags["F_CONTIGUOUS"]
 
     if not ok:
         if strict:
             raise ValueError(
                 "Fortran bending kernels require F-contiguous u/v (to avoid hidden copies)."
             )
-        return _grad_cotan_numpy(u, v)
+        if kernel_spec.expects_transpose:
+            u_arg = np.asfortranarray(u_arg.T).T
+            v_arg = np.asfortranarray(v_arg.T).T
+        else:
+            u_arg = np.asfortranarray(u_arg)
+            v_arg = np.asfortranarray(v_arg)
 
     if kernel_spec.expects_transpose:
+        u_t = (
+            u_arg.T
+            if u_arg.T.flags["F_CONTIGUOUS"]
+            else np.asfortranarray(u_arg.T, dtype=np.float64)
+        )
+        v_t = (
+            v_arg.T
+            if v_arg.T.flags["F_CONTIGUOUS"]
+            else np.asfortranarray(v_arg.T, dtype=np.float64)
+        )
         try:
-            gu_t = np.zeros_like(u.T, order="F")
-            gv_t = np.zeros_like(v.T, order="F")
-            kernel_spec.func(u.T, v.T, gu_t, gv_t)
+            gu_t = np.zeros_like(u_t, order="F")
+            gv_t = np.zeros_like(v_t, order="F")
+            kernel_spec.func(u_t, v_t, gu_t, gv_t)
             return gu_t.T, gv_t.T
         except Exception:
-            gu_t, gv_t = kernel_spec.func(u.T, v.T)
+            gu_t, gv_t = kernel_spec.func(u_t, v_t)
             return np.asarray(gu_t).T, np.asarray(gv_t).T
 
+    if not u_arg.flags["F_CONTIGUOUS"]:
+        u_arg = np.asfortranarray(u_arg, dtype=np.float64)
+    if not v_arg.flags["F_CONTIGUOUS"]:
+        v_arg = np.asfortranarray(v_arg, dtype=np.float64)
     try:
-        gu = np.zeros_like(u, order="F")
-        gv = np.zeros_like(v, order="F")
-        kernel_spec.func(u, v, gu, gv)
+        gu = np.zeros_like(u_arg, order="F")
+        gv = np.zeros_like(v_arg, order="F")
+        kernel_spec.func(u_arg, v_arg, gu, gv)
         return gu, gv
     except Exception:
-        gu, gv = kernel_spec.func(u, v)
+        gu, gv = kernel_spec.func(u_arg, v_arg)
         return np.asarray(gu), np.asarray(gv)
 
 

--- a/modules/energy/tilt_in.py
+++ b/modules/energy/tilt_in.py
@@ -15,12 +15,9 @@ from typing import Dict, Tuple
 import numpy as np
 
 from geometry.entities import Mesh
+from modules.constraints.local_interface_shells import build_local_interface_shell_data
 from modules.energy import tilt_leaflet
-from modules.energy.tilt_utils import (
-    _active_row_weights,
-    _resolve_exclude_shared_rim_rows,
-    _resolve_shared_rim_outer_shell_mass_mode,
-)
+from modules.energy import tilt_utils as _tilt_utils
 
 USES_TILT_LEAFLETS = True
 
@@ -86,11 +83,48 @@ def compute_energy_array(
     )
 
 
+def _active_row_weights(mesh: Mesh, param_resolver) -> np.ndarray | None:
+    return _tilt_utils._active_row_weights(mesh, param_resolver, "in")
+
+
+def _resolve_exclude_shared_rim_rows(param_resolver) -> bool:
+    return _tilt_utils._resolve_exclude_shared_rim_rows(param_resolver)
+
+
+def _shared_rim_outer_shell_rows(mesh: Mesh) -> np.ndarray:
+    return _tilt_utils._shared_rim_outer_shell_rows(mesh, "in")
+
+
+def _resolve_shared_rim_outer_row_energy_weight(param_resolver) -> float | None:
+    return _tilt_utils._resolve_shared_rim_outer_row_energy_weight(param_resolver, "in")
+
+
+def _resolve_shared_rim_outer_shell_mass_mode(param_resolver) -> str | None:
+    return _tilt_utils._resolve_shared_rim_outer_shell_mass_mode(param_resolver, "in")
+
+
+def _explicit_trace_layer_active_row_weights(
+    mesh: Mesh, param_resolver
+) -> np.ndarray | None:
+    return _tilt_utils._explicit_trace_layer_active_row_weights(
+        mesh, param_resolver, "in"
+    )
+
+
+def _shared_rim_active_row_weights(mesh: Mesh, param_resolver) -> np.ndarray | None:
+    return _tilt_utils._shared_rim_active_row_weights(mesh, param_resolver, "in")
+
+
 __all__ = [
     "compute_energy_and_gradient",
     "compute_energy_and_gradient_array",
     "compute_energy_array",
     "_active_row_weights",
     "_resolve_exclude_shared_rim_rows",
+    "_shared_rim_outer_shell_rows",
+    "_resolve_shared_rim_outer_row_energy_weight",
     "_resolve_shared_rim_outer_shell_mass_mode",
+    "_explicit_trace_layer_active_row_weights",
+    "_shared_rim_active_row_weights",
+    "build_local_interface_shell_data",
 ]

--- a/modules/energy/tilt_out.py
+++ b/modules/energy/tilt_out.py
@@ -15,10 +15,9 @@ from typing import Dict, Tuple
 import numpy as np
 
 from geometry.entities import Mesh
+from modules.constraints.local_interface_shells import build_local_interface_shell_data
 from modules.energy import tilt_leaflet
-from modules.energy.tilt_utils import (
-    _active_row_weights,
-)
+from modules.energy import tilt_utils as _tilt_utils
 
 USES_TILT_LEAFLETS = True
 
@@ -84,9 +83,45 @@ def compute_energy_array(
     )
 
 
+def _active_row_weights(mesh: Mesh, param_resolver) -> np.ndarray | None:
+    return _tilt_utils._active_row_weights(mesh, param_resolver, "out")
+
+
+def _shared_rim_outer_shell_rows(mesh: Mesh) -> np.ndarray:
+    return _tilt_utils._shared_rim_outer_shell_rows(mesh, "out")
+
+
+def _resolve_shared_rim_outer_row_energy_weight(param_resolver) -> float | None:
+    return _tilt_utils._resolve_shared_rim_outer_row_energy_weight(
+        param_resolver, "out"
+    )
+
+
+def _resolve_shared_rim_outer_shell_mass_mode(param_resolver) -> str | None:
+    return _tilt_utils._resolve_shared_rim_outer_shell_mass_mode(param_resolver, "out")
+
+
+def _explicit_trace_layer_active_row_weights(
+    mesh: Mesh, param_resolver
+) -> np.ndarray | None:
+    return _tilt_utils._explicit_trace_layer_active_row_weights(
+        mesh, param_resolver, "out"
+    )
+
+
+def _shared_rim_active_row_weights(mesh: Mesh, param_resolver) -> np.ndarray | None:
+    return _tilt_utils._shared_rim_active_row_weights(mesh, param_resolver, "out")
+
+
 __all__ = [
     "compute_energy_and_gradient",
     "compute_energy_and_gradient_array",
     "compute_energy_array",
     "_active_row_weights",
+    "_shared_rim_outer_shell_rows",
+    "_resolve_shared_rim_outer_row_energy_weight",
+    "_resolve_shared_rim_outer_shell_mass_mode",
+    "_explicit_trace_layer_active_row_weights",
+    "_shared_rim_active_row_weights",
+    "build_local_interface_shell_data",
 ]

--- a/modules/energy/tilt_smoothness_in.py
+++ b/modules/energy/tilt_smoothness_in.py
@@ -16,6 +16,7 @@ import numpy as np
 
 from geometry.entities import Mesh
 from modules.energy import tilt_smoothness_leaflet as _leaflet
+from modules.energy import tilt_smoothness_utils as _utils
 
 USES_TILT_LEAFLETS = True
 
@@ -90,8 +91,18 @@ def compute_energy_array(
     )
 
 
+def _masked_weights_and_tris(mesh: Mesh, global_params, **kwargs):
+    return _utils._masked_weights_and_tris(mesh, global_params, leaflet="in", **kwargs)
+
+
+def _resolve_smoothness_rigidity(param_resolver) -> float:
+    return _utils._resolve_smoothness_rigidity(param_resolver, "in")
+
+
 __all__ = [
     "compute_energy_and_gradient",
     "compute_energy_and_gradient_array",
     "compute_energy_array",
+    "_masked_weights_and_tris",
+    "_resolve_smoothness_rigidity",
 ]

--- a/modules/energy/tilt_smoothness_out.py
+++ b/modules/energy/tilt_smoothness_out.py
@@ -16,6 +16,7 @@ import numpy as np
 
 from geometry.entities import Mesh
 from modules.energy import tilt_smoothness_leaflet as _leaflet
+from modules.energy import tilt_smoothness_utils as _utils
 
 USES_TILT_LEAFLETS = True
 
@@ -90,8 +91,18 @@ def compute_energy_array(
     )
 
 
+def _masked_weights_and_tris(mesh: Mesh, global_params, **kwargs):
+    return _utils._masked_weights_and_tris(mesh, global_params, leaflet="out", **kwargs)
+
+
+def _resolve_smoothness_rigidity(param_resolver) -> float:
+    return _utils._resolve_smoothness_rigidity(param_resolver, "out")
+
+
 __all__ = [
     "compute_energy_and_gradient",
     "compute_energy_and_gradient_array",
     "compute_energy_array",
+    "_masked_weights_and_tris",
+    "_resolve_smoothness_rigidity",
 ]

--- a/runtime/minimizer.py
+++ b/runtime/minimizer.py
@@ -112,6 +112,10 @@ class Minimizer:
         self._soa_grad_dummy: np.ndarray | None = None
         self._last_mesh_op_tilt_constraints_enforced: bool = False
         self._energy_context: EnergyContext | None = None
+        self._module_accepts_ctx: dict[int, bool] = {}
+        self._module_energy_array_spec: dict[
+            int, tuple[bool, bool, frozenset[str] | None]
+        ] = {}
         self._stepper_accepts_trial_energy_fn: bool | None = None
         self._last_tilt_projection_stats: dict[str, float | int | str] = {
             "projection_cadence": "per_step",
@@ -175,6 +179,14 @@ class Minimizer:
         self._module_accepts_ctx = {}
         self._stepper_accepts_trial_energy_fn = None
 
+    def _sync_evaluation_manager(self) -> None:
+        """Keep the extracted evaluator aligned with mutable minimizer state."""
+        self._evaluation_manager.mesh = self.mesh
+        self._evaluation_manager.global_params = self.global_params
+        self._evaluation_manager.param_resolver = self.param_resolver
+        self._evaluation_manager.energy_modules = self.energy_modules
+        self._evaluation_manager.energy_module_names = self.energy_module_names
+
     def _validate_energy_modules_array(self) -> None:
         """Ensure energy modules support the array API required by minimization."""
         for module in self.energy_modules:
@@ -213,15 +225,95 @@ class Minimizer:
 
     def _call_module_array(self, module, **kwargs):
         """Call module array API with explicit ctx and graceful fallback."""
-        return self._evaluation_manager._call_module_array(module, **kwargs)
+        key = id(module)
+        accepts_ctx = self._module_accepts_ctx.get(key)
+        if accepts_ctx is None:
+            accepts_ctx = False
+            fn = getattr(module, "compute_energy_and_gradient_array", None)
+            if fn is not None:
+                try:
+                    sig = inspect.signature(fn)
+                    if "ctx" in sig.parameters:
+                        accepts_ctx = True
+                    else:
+                        accepts_ctx = any(
+                            p.kind is inspect.Parameter.VAR_KEYWORD
+                            for p in sig.parameters.values()
+                        )
+                except (TypeError, ValueError):
+                    accepts_ctx = False
+            self._module_accepts_ctx[key] = accepts_ctx
+
+        if accepts_ctx:
+            return module.compute_energy_and_gradient_array(
+                self.mesh,
+                self.global_params,
+                self.param_resolver,
+                ctx=self.energy_context(),
+                **kwargs,
+            )
+        return module.compute_energy_and_gradient_array(
+            self.mesh,
+            self.global_params,
+            self.param_resolver,
+            **kwargs,
+        )
 
     def _call_module_energy_array(self, module, **kwargs):
-        """Call module energy-only array API with explicit ctx and fallback."""
-        return self._evaluation_manager._call_module_energy_array(module, **kwargs)
+        """Call energy-only array API while honoring per-module signatures."""
+        fn = getattr(module, "compute_energy_array")
+        key = id(module)
+        spec = self._module_energy_array_spec.get(key)
+        if spec is None:
+            accepts_resolver = False
+            accepts_ctx = False
+            accepted_kwargs: frozenset[str] | None = frozenset()
+            try:
+                sig = inspect.signature(fn)
+                params = sig.parameters
+                accepts_resolver = "param_resolver" in params
+                accepts_var_kwargs = any(
+                    p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()
+                )
+                accepts_ctx = "ctx" in params or accepts_var_kwargs
+                if accepts_var_kwargs:
+                    accepted_kwargs = None
+                else:
+                    accepted_kwargs = frozenset(
+                        name
+                        for name, param in params.items()
+                        if param.kind
+                        in (
+                            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                            inspect.Parameter.KEYWORD_ONLY,
+                        )
+                    )
+            except (TypeError, ValueError):
+                accepted_kwargs = None
+            spec = (accepts_resolver, accepts_ctx, accepted_kwargs)
+            self._module_energy_array_spec[key] = spec
 
-    def _coerce_energy_value(self, energy_value) -> float:
+        accepts_resolver, accepts_ctx, accepted_kwargs = spec
+        call_kwargs = kwargs
+        if accepted_kwargs is not None:
+            call_kwargs = {
+                name: value for name, value in kwargs.items() if name in accepted_kwargs
+            }
+        if accepts_ctx:
+            call_kwargs = dict(call_kwargs)
+            call_kwargs["ctx"] = self.energy_context()
+
+        if accepts_resolver:
+            return fn(self.mesh, self.global_params, self.param_resolver, **call_kwargs)
+        return fn(self.mesh, self.global_params, **call_kwargs)
+
+    @staticmethod
+    def _coerce_energy_value(energy_value) -> float:
         """Normalize scalar- or array-valued module energies to a float total."""
-        return self._evaluation_manager._coerce_energy_value(energy_value)
+        energy_arr = np.asarray(energy_value, dtype=float)
+        if energy_arr.ndim == 0:
+            return float(energy_arr)
+        return float(np.sum(energy_arr))
 
     def _soa_views(self) -> tuple[np.ndarray, Dict[int, int], np.ndarray]:
         """Return cached SoA views for positions, index map, and a scratch buffer."""
@@ -533,7 +625,43 @@ class Minimizer:
 
     def _compute_energy_array_total(self, *, positions: np.ndarray) -> float:
         """Compute total energy for fixed positions and the current mesh tilt state."""
-        return self._evaluation_manager.compute_energy_array_total(positions=positions)
+        index_map = self.mesh.vertex_index_to_row
+        grad_dummy = self.energy_context().scratch_array(
+            "energy_only_grad_dummy", shape=positions.shape, dtype=positions.dtype
+        )
+        total_energy = 0.0
+
+        for name, module in zip(self.energy_module_names, self.energy_modules):
+            scale = self._experimental_energy_scale_for_module(str(name))
+            if hasattr(module, "compute_energy_array"):
+                E_mod = self._call_module_energy_array(
+                    module,
+                    positions=positions,
+                    index_map=index_map,
+                )
+                total_energy += float(scale) * self._coerce_energy_value(E_mod)
+                continue
+
+            if hasattr(module, "compute_energy_and_gradient_array"):
+                grad_dummy.fill(0.0)
+                E_mod = self._call_module_array(
+                    module,
+                    positions=positions,
+                    index_map=index_map,
+                    grad_arr=grad_dummy,
+                )
+                total_energy += float(scale) * self._coerce_energy_value(E_mod)
+                continue
+
+            E_mod, _ = module.compute_energy_and_gradient(
+                self.mesh,
+                self.global_params,
+                self.param_resolver,
+                compute_gradient=False,
+            )
+            total_energy += float(scale) * self._coerce_energy_value(E_mod)
+
+        return float(total_energy)
 
     def _compute_total_energy_array_with_tilts(
         self,
@@ -542,9 +670,69 @@ class Minimizer:
         tilts: np.ndarray,
     ) -> float:
         """Compute total energy for fixed positions and a projected tilt field."""
-        return self._evaluation_manager.compute_total_energy_array_with_tilts(
-            positions=positions, tilts=tilts
+        index_map = self.mesh.vertex_index_to_row
+        grad_dummy = self.energy_context().scratch_array(
+            "energy_only_tilt_grad_dummy", shape=positions.shape, dtype=positions.dtype
         )
+        total_energy = 0.0
+
+        for name, module in zip(self.energy_module_names, self.energy_modules):
+            scale = self._experimental_energy_scale_for_module(str(name))
+            if hasattr(module, "compute_energy_array"):
+                kwargs = {"positions": positions, "index_map": index_map}
+                if getattr(module, "USES_TILT", False):
+                    kwargs["tilts"] = tilts
+                E_mod = self._call_module_energy_array(module, **kwargs)
+                total_energy += float(scale) * self._coerce_energy_value(E_mod)
+                continue
+
+            if hasattr(module, "compute_energy_and_gradient_array"):
+                grad_dummy.fill(0.0)
+                if getattr(module, "USES_TILT", False):
+                    try:
+                        E_mod = self._call_module_array(
+                            module,
+                            positions=positions,
+                            index_map=index_map,
+                            grad_arr=grad_dummy,
+                            tilts=tilts,
+                            tilt_grad_arr=None,
+                        )
+                    except TypeError:
+                        try:
+                            E_mod = self._call_module_array(
+                                module,
+                                positions=positions,
+                                index_map=index_map,
+                                grad_arr=grad_dummy,
+                                tilts=tilts,
+                            )
+                        except TypeError:
+                            E_mod = self._call_module_array(
+                                module,
+                                positions=positions,
+                                index_map=index_map,
+                                grad_arr=grad_dummy,
+                            )
+                else:
+                    E_mod = self._call_module_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                        grad_arr=grad_dummy,
+                    )
+                total_energy += float(scale) * self._coerce_energy_value(E_mod)
+                continue
+
+            E_mod, _ = module.compute_energy_and_gradient(
+                self.mesh,
+                self.global_params,
+                self.param_resolver,
+                compute_gradient=False,
+            )
+            total_energy += float(scale) * self._coerce_energy_value(E_mod)
+
+        return float(total_energy)
 
     def _compute_energy_array_with_tilts(
         self,
@@ -552,10 +740,91 @@ class Minimizer:
         positions: np.ndarray,
         tilts: np.ndarray,
     ) -> float:
-        """Compute tilt-dependent energy for fixed ``positions``/``tilts``."""
-        return self._evaluation_manager.compute_energy_array_with_tilts(
-            positions=positions, tilts=tilts
-        )
+        """Compute tilt-dependent energy for fixed ``positions``/``tilts``.
+
+        Uses the array API when available and passes ``tilts`` opportunistically
+        (falling back when a module does not accept tilt arguments).
+        """
+        index_map = self.mesh.vertex_index_to_row
+        grad_dummy = np.zeros_like(positions)
+        total_energy = 0.0
+
+        module_names = self.energy_module_names
+        if len(module_names) != len(self.energy_modules):
+            module_names = [
+                getattr(module, "__name__", module.__class__.__name__)
+                for module in self.energy_modules
+            ]
+
+        for name, module in zip(module_names, self.energy_modules):
+            scale = self._experimental_energy_scale_for_module(str(name))
+            if not getattr(module, "USES_TILT", False):
+                continue
+            if hasattr(module, "compute_energy_array"):
+                try:
+                    E_mod = module.compute_energy_array(
+                        self.mesh,
+                        self.global_params,
+                        self.param_resolver,
+                        positions=positions,
+                        index_map=index_map,
+                        tilts=tilts,
+                    )
+                except TypeError:
+                    E_mod = module.compute_energy_array(
+                        self.mesh,
+                        self.global_params,
+                        self.param_resolver,
+                        positions=positions,
+                        index_map=index_map,
+                    )
+                total_energy += float(scale) * float(E_mod)
+                continue
+
+            if hasattr(module, "compute_energy_and_gradient_array"):
+                try:
+                    E_mod = self._call_module_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                        grad_arr=grad_dummy,
+                        tilts=tilts,
+                        tilt_grad_arr=None,
+                    )
+                except TypeError:
+                    try:
+                        E_mod = self._call_module_array(
+                            module,
+                            positions=positions,
+                            index_map=index_map,
+                            grad_arr=grad_dummy,
+                            tilts=tilts,
+                        )
+                    except TypeError:
+                        E_mod = self._call_module_array(
+                            module,
+                            positions=positions,
+                            index_map=index_map,
+                            grad_arr=grad_dummy,
+                        )
+                total_energy += float(scale) * float(E_mod)
+                continue
+
+            # Legacy dict modules (typically tilt-independent): energy-only path.
+            try:
+                E_mod, _ = module.compute_energy_and_gradient(
+                    self.mesh,
+                    self.global_params,
+                    self.param_resolver,
+                    compute_gradient=False,
+                )
+            except TypeError:
+                E_mod, _ = module.compute_energy_and_gradient(
+                    self.mesh, self.global_params, self.param_resolver
+                )
+            total_energy += float(scale) * float(E_mod)
+
+        return float(total_energy)
 
     def _compute_energy_and_tilt_gradient_array(
         self,
@@ -565,9 +834,76 @@ class Minimizer:
         tilt_grad_arr: np.ndarray,
     ) -> float:
         """Compute tilt-dependent energy and accumulate dense tilt gradient."""
-        return self._evaluation_manager.compute_energy_and_tilt_gradient_array(
-            positions=positions, tilts=tilts, tilt_grad_arr=tilt_grad_arr
-        )
+        index_map = self.mesh.vertex_index_to_row
+        grad_dummy = np.zeros_like(positions)
+        tilt_grad_arr.fill(0.0)
+        total_energy = 0.0
+
+        module_names = self.energy_module_names
+        if len(module_names) != len(self.energy_modules):
+            module_names = [
+                getattr(module, "__name__", module.__class__.__name__)
+                for module in self.energy_modules
+            ]
+
+        for name, module in zip(module_names, self.energy_modules):
+            scale = self._experimental_energy_scale_for_module(str(name))
+            if not getattr(module, "USES_TILT", False):
+                continue
+            if hasattr(module, "compute_energy_and_gradient_array"):
+                grad_before = None
+                if abs(float(scale) - 1.0) > 1.0e-15:
+                    grad_before = tilt_grad_arr.copy()
+                try:
+                    E_mod = self._call_module_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                        grad_arr=grad_dummy,
+                        tilts=tilts,
+                        tilt_grad_arr=tilt_grad_arr,
+                    )
+                except TypeError:
+                    try:
+                        E_mod = self._call_module_array(
+                            module,
+                            positions=positions,
+                            index_map=index_map,
+                            grad_arr=grad_dummy,
+                            tilts=tilts,
+                        )
+                    except TypeError:
+                        E_mod = self._call_module_array(
+                            module,
+                            positions=positions,
+                            index_map=index_map,
+                            grad_arr=grad_dummy,
+                        )
+                if grad_before is not None:
+                    grad_delta = tilt_grad_arr - grad_before
+                    tilt_grad_arr[:] = grad_before + (float(scale) * grad_delta)
+                total_energy += float(scale) * float(E_mod)
+                continue
+
+            # Dict fallback: accept modules that optionally return a tilt gradient.
+            res = module.compute_energy_and_gradient(
+                self.mesh, self.global_params, self.param_resolver
+            )
+
+            if not isinstance(res, tuple) or len(res) < 2:
+                raise ValueError(
+                    f"Unexpected return from energy module {module}: {res!r}"
+                )
+
+            total_energy += float(scale) * float(res[0])
+            if len(res) >= 3 and res[2] is not None:
+                g_tilt = res[2]
+                for vidx, gvec in g_tilt.items():
+                    row = index_map.get(int(vidx))
+                    if row is not None:
+                        tilt_grad_arr[row] += float(scale) * gvec
+
+        return float(total_energy)
 
     def _compute_energy_array_with_leaflet_tilts(
         self,
@@ -578,12 +914,73 @@ class Minimizer:
         grad_dummy: np.ndarray | None = None,
     ) -> float:
         """Compute total energy for fixed positions and leaflet tilt arrays."""
-        return self._evaluation_manager.compute_energy_array_with_leaflet_tilts(
-            positions=positions,
-            tilts_in=tilts_in,
-            tilts_out=tilts_out,
-            grad_dummy=grad_dummy,
-        )
+        index_map = self.mesh.vertex_index_to_row
+        if grad_dummy is None:
+            grad_dummy = np.zeros_like(positions)
+        else:
+            grad_dummy.fill(0.0)
+        total_energy = 0.0
+
+        for name, module in zip(self.energy_module_names, self.energy_modules):
+            scale = self._experimental_energy_scale_for_module(str(name))
+            if hasattr(module, "compute_energy_array"):
+                try:
+                    E_mod = module.compute_energy_array(
+                        self.mesh,
+                        self.global_params,
+                        self.param_resolver,
+                        positions=positions,
+                        index_map=index_map,
+                        tilts_in=tilts_in,
+                        tilts_out=tilts_out,
+                    )
+                except TypeError:
+                    E_mod = module.compute_energy_array(
+                        self.mesh,
+                        self.global_params,
+                        self.param_resolver,
+                        positions=positions,
+                        index_map=index_map,
+                    )
+                total_energy += float(scale) * float(E_mod)
+                continue
+
+            if hasattr(module, "compute_energy_and_gradient_array"):
+                try:
+                    E_mod = self._call_module_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                        grad_arr=grad_dummy,
+                        tilts_in=tilts_in,
+                        tilts_out=tilts_out,
+                        tilt_in_grad_arr=None,
+                        tilt_out_grad_arr=None,
+                    )
+                except TypeError:
+                    E_mod = self._call_module_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                        grad_arr=grad_dummy,
+                    )
+                total_energy += float(scale) * float(E_mod)
+                continue
+
+            try:
+                E_mod, _ = module.compute_energy_and_gradient(
+                    self.mesh,
+                    self.global_params,
+                    self.param_resolver,
+                    compute_gradient=False,
+                )
+            except TypeError:
+                E_mod, _ = module.compute_energy_and_gradient(
+                    self.mesh, self.global_params, self.param_resolver
+                )
+            total_energy += float(scale) * float(E_mod)
+
+        return float(total_energy)
 
     def _compute_tilt_dependent_energy_with_leaflet_tilts(
         self,
@@ -595,17 +992,95 @@ class Minimizer:
         tilt_vertex_areas_in: np.ndarray | None = None,
         tilt_vertex_areas_out: np.ndarray | None = None,
     ) -> float:
-        """Compute energy of tilt-dependent modules only (positions frozen)."""
-        return (
-            self._evaluation_manager.compute_tilt_dependent_energy_with_leaflet_tilts(
+        """Compute energy of tilt-dependent modules only (positions frozen).
+
+        This is used inside inner-loop tilt relaxation. Shape-only energy terms
+        are constant when positions are frozen, so dropping them preserves
+        backtracking accept/reject decisions while avoiding extra work.
+        """
+        index_map = self.mesh.vertex_index_to_row
+        if grad_dummy is None:
+            grad_dummy = np.zeros_like(positions)
+        else:
+            grad_dummy.fill(0.0)
+        total_energy = 0.0
+
+        for name, module in zip(self.energy_module_names, self.energy_modules):
+            scale = self._experimental_energy_scale_for_module(str(name))
+            if not getattr(module, "USES_TILT_LEAFLETS", False):
+                continue
+
+            # Fast path for pure tilt magnitude penalties.
+            if name == "tilt_in" and tilt_vertex_areas_in is not None:
+                k_tilt = float(self.param_resolver.get(None, "tilt_modulus_in") or 0.0)
+                if k_tilt != 0.0:
+                    sq = np.einsum("ij,ij->i", tilts_in, tilts_in)
+                    total_energy += float(
+                        float(scale) * 0.5 * k_tilt * np.sum(sq * tilt_vertex_areas_in)
+                    )
+                continue
+            if name == "tilt_out" and tilt_vertex_areas_out is not None:
+                k_tilt = float(self.param_resolver.get(None, "tilt_modulus_out") or 0.0)
+                if k_tilt != 0.0:
+                    sq = np.einsum("ij,ij->i", tilts_out, tilts_out)
+                    total_energy += float(
+                        float(scale) * 0.5 * k_tilt * np.sum(sq * tilt_vertex_areas_out)
+                    )
+                continue
+
+            if hasattr(module, "compute_energy_array"):
+                try:
+                    E_mod = self._call_module_energy_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                        tilts_in=tilts_in,
+                        tilts_out=tilts_out,
+                    )
+                except TypeError:
+                    # Some tilt modules ignore passed tilts and read from mesh.
+                    E_mod = self._call_module_energy_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                    )
+                total_energy += float(scale) * float(E_mod)
+                continue
+
+            if hasattr(module, "compute_energy_and_gradient_array"):
+                try:
+                    E_mod = self._call_module_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                        grad_arr=None,
+                        tilts_in=tilts_in,
+                        tilts_out=tilts_out,
+                        tilt_in_grad_arr=None,
+                        tilt_out_grad_arr=None,
+                    )
+                except TypeError:
+                    # Some tilt modules ignore passed tilts and read from mesh.
+                    E_mod = self._call_module_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                        grad_arr=None,
+                    )
+                total_energy += float(scale) * float(E_mod)
+                continue
+
+            # Legacy dict modules are rare here; fall back to full energy.
+            # (Inner-loop performance comes from the array modules.)
+            E_full = self._compute_energy_array_with_leaflet_tilts(
                 positions=positions,
                 tilts_in=tilts_in,
                 tilts_out=tilts_out,
                 grad_dummy=grad_dummy,
-                tilt_vertex_areas_in=tilt_vertex_areas_in,
-                tilt_vertex_areas_out=tilt_vertex_areas_out,
             )
-        )
+            return float(E_full)
+
+        return float(total_energy)
 
     def _compute_energy_and_leaflet_tilt_gradients_array(
         self,
@@ -621,17 +1096,102 @@ class Minimizer:
         tilt_only: bool = False,
     ) -> float:
         """Compute total energy and accumulate leaflet tilt gradients."""
-        return self._evaluation_manager.compute_energy_and_leaflet_tilt_gradients_array(
-            positions=positions,
-            tilts_in=tilts_in,
-            tilts_out=tilts_out,
-            tilt_in_grad_arr=tilt_in_grad_arr,
-            tilt_out_grad_arr=tilt_out_grad_arr,
-            tilt_vertex_areas_in=tilt_vertex_areas_in,
-            tilt_vertex_areas_out=tilt_vertex_areas_out,
-            grad_dummy=grad_dummy,
-            tilt_only=tilt_only,
-        )
+        index_map = self.mesh.vertex_index_to_row
+        if grad_dummy is None:
+            grad_dummy = np.zeros_like(positions)
+        else:
+            grad_dummy.fill(0.0)
+        tilt_in_grad_arr.fill(0.0)
+        tilt_out_grad_arr.fill(0.0)
+        total_energy = 0.0
+
+        for name, module in zip(self.energy_module_names, self.energy_modules):
+            scale = self._experimental_energy_scale_for_module(str(name))
+            # Fast path for the pure tilt magnitude penalties: when positions
+            # are frozen (tilt relaxation inner loop), precomputed vertex areas
+            # avoid repeated triangle cross-products.
+            if (
+                name == "tilt_in"
+                and tilt_vertex_areas_in is not None
+                and getattr(module, "USES_TILT_LEAFLETS", False)
+            ):
+                k_tilt = float(self.param_resolver.get(None, "tilt_modulus_in") or 0.0)
+                if k_tilt != 0.0:
+                    sq = np.einsum("ij,ij->i", tilts_in, tilts_in)
+                    total_energy += float(
+                        float(scale) * 0.5 * k_tilt * np.sum(sq * tilt_vertex_areas_in)
+                    )
+                    tilt_in_grad_arr += (
+                        float(scale) * k_tilt * tilts_in * tilt_vertex_areas_in[:, None]
+                    )
+                continue
+
+            if (
+                name == "tilt_out"
+                and tilt_vertex_areas_out is not None
+                and getattr(module, "USES_TILT_LEAFLETS", False)
+            ):
+                k_tilt = float(self.param_resolver.get(None, "tilt_modulus_out") or 0.0)
+                if k_tilt != 0.0:
+                    sq = np.einsum("ij,ij->i", tilts_out, tilts_out)
+                    total_energy += float(
+                        float(scale) * 0.5 * k_tilt * np.sum(sq * tilt_vertex_areas_out)
+                    )
+                    tilt_out_grad_arr += (
+                        float(scale)
+                        * k_tilt
+                        * tilts_out
+                        * tilt_vertex_areas_out[:, None]
+                    )
+                continue
+
+            if hasattr(module, "compute_energy_and_gradient_array"):
+                grad_arg = (
+                    None
+                    if tilt_only and getattr(module, "USES_TILT_LEAFLETS", False)
+                    else grad_dummy
+                )
+                in_before = None
+                out_before = None
+                if abs(float(scale) - 1.0) > 1.0e-15:
+                    in_before = tilt_in_grad_arr.copy()
+                    out_before = tilt_out_grad_arr.copy()
+                try:
+                    E_mod = self._call_module_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                        grad_arr=grad_arg,
+                        tilts_in=tilts_in,
+                        tilts_out=tilts_out,
+                        tilt_in_grad_arr=tilt_in_grad_arr,
+                        tilt_out_grad_arr=tilt_out_grad_arr,
+                    )
+                except TypeError:
+                    E_mod = self._call_module_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                        grad_arr=grad_arg,
+                    )
+                if in_before is not None and out_before is not None:
+                    in_delta = tilt_in_grad_arr - in_before
+                    out_delta = tilt_out_grad_arr - out_before
+                    tilt_in_grad_arr[:] = in_before + (float(scale) * in_delta)
+                    tilt_out_grad_arr[:] = out_before + (float(scale) * out_delta)
+                total_energy += float(scale) * float(E_mod)
+                continue
+
+            res = module.compute_energy_and_gradient(
+                self.mesh, self.global_params, self.param_resolver
+            )
+            if not isinstance(res, tuple) or len(res) < 2:
+                raise ValueError(
+                    f"Unexpected return from energy module {module}: {res!r}"
+                )
+            total_energy += float(scale) * float(res[0])
+
+        return float(total_energy)
 
     def _relax_tilts(
         self,
@@ -683,10 +1243,9 @@ class Minimizer:
     def refresh_modules(self):
         """Re-load energy and constraint modules from the current mesh state."""
         # Refresh energy modules
-        module_list = list(self.mesh.energy_modules)
-        self.energy_module_names = module_list
+        self.energy_module_names = list(self.mesh.energy_modules)
         self.energy_modules = [
-            self.energy_manager.get_module(mod) for mod in module_list
+            self.energy_manager.get_module(mod) for mod in self.mesh.energy_modules
         ]
         # Refresh constraint modules
         self.constraint_modules = [
@@ -696,11 +1255,7 @@ class Minimizer:
         self._has_enforceable_constraints = any(
             hasattr(mod, "enforce_constraint") for mod in self.constraint_modules
         )
-
-        self._evaluation_manager.energy_modules = self.energy_modules
-        self._evaluation_manager.energy_module_names = self.energy_module_names
-        self._evaluation_manager.mesh = self.mesh
-
+        self._sync_evaluation_manager()
         self.reset_soa_caches()
         logger.info(
             f"Minimizer modules refreshed: {len(self.energy_modules)} energy, {len(self.constraint_modules)} constraint."

--- a/tests/test_curvature_kernel_optional_outputs_unit.py
+++ b/tests/test_curvature_kernel_optional_outputs_unit.py
@@ -96,3 +96,28 @@ def test_curvature_kernel_legacy_signature_still_supported(
     assert "va0_raw" not in mesh._curvature_cache
     assert "va1_raw" not in mesh._curvature_cache
     assert "va2_raw" not in mesh._curvature_cache
+
+
+def test_curvature_kernel_strict_nocopy_rejects_non_fortran_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mesh = _single_triangle_mesh()
+    pos = mesh.positions_view()
+    idx = mesh.vertex_index_to_row
+    called = False
+
+    def _kernel(pos_in, tri_in, k_vecs, vertex_areas, weights, zero_based):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(
+        loader,
+        "get_tilt_curvature_kernel",
+        lambda: SimpleNamespace(func=_kernel, expects_transpose=False),
+    )
+    monkeypatch.setenv("MEMBRANE_FORTRAN_STRICT_NOCOPY", "1")
+
+    assert not pos.flags["F_CONTIGUOUS"]
+    with pytest.raises(ValueError, match="F-contiguous positions/tri_rows"):
+        compute_curvature_data(mesh, pos, idx)
+    assert called is False

--- a/tests/test_refactor_compatibility.py
+++ b/tests/test_refactor_compatibility.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+from core.parameters.global_parameters import GlobalParameters
+from geometry.entities import Mesh, Vertex
+from runtime.constraint_manager import ConstraintModuleManager
+from runtime.energy_manager import EnergyModuleManager
+from runtime.minimizer import Minimizer
+from runtime.steppers.gradient_descent import GradientDescent
+
+
+def _single_vertex_mesh() -> Mesh:
+    mesh = Mesh()
+    mesh.vertices = {0: Vertex(0, np.zeros(3, dtype=float))}
+    mesh.edges = {}
+    mesh.facets = {}
+    mesh.energy_modules = []
+    mesh.constraint_modules = []
+    mesh.global_parameters = GlobalParameters()
+    mesh.build_position_cache()
+    return mesh
+
+
+def test_tilt_front_modules_keep_legacy_helper_shims(monkeypatch) -> None:
+    tilt_in = importlib.import_module("modules.energy.tilt_in")
+    tilt_out = importlib.import_module("modules.energy.tilt_out")
+
+    mesh = _single_vertex_mesh()
+    resolver = object()
+
+    def fake_outer_shell(mesh_arg, leaflet):
+        assert mesh_arg is mesh
+        return np.asarray([0 if leaflet == "in" else 1], dtype=int)
+
+    def fake_trace_weights(mesh_arg, resolver_arg, leaflet):
+        assert mesh_arg is mesh
+        assert resolver_arg is resolver
+        return np.asarray([2.0 if leaflet == "in" else 3.0])
+
+    monkeypatch.setattr(
+        tilt_in._tilt_utils, "_shared_rim_outer_shell_rows", fake_outer_shell
+    )
+    monkeypatch.setattr(
+        tilt_in._tilt_utils,
+        "_explicit_trace_layer_active_row_weights",
+        fake_trace_weights,
+    )
+
+    assert tilt_in._shared_rim_outer_shell_rows(mesh).tolist() == [0]
+    assert tilt_out._shared_rim_outer_shell_rows(mesh).tolist() == [1]
+    assert tilt_in._explicit_trace_layer_active_row_weights(
+        mesh, resolver
+    ).tolist() == [2.0]
+    assert tilt_out._explicit_trace_layer_active_row_weights(
+        mesh, resolver
+    ).tolist() == [3.0]
+    assert hasattr(tilt_in, "build_local_interface_shell_data")
+    assert hasattr(tilt_out, "build_local_interface_shell_data")
+
+
+def test_tilt_smoothness_front_modules_keep_legacy_helper_shims(monkeypatch) -> None:
+    smooth_in = importlib.import_module("modules.energy.tilt_smoothness_in")
+    smooth_out = importlib.import_module("modules.energy.tilt_smoothness_out")
+
+    resolver = object()
+
+    def fake_rigidity(resolver_arg, leaflet):
+        assert resolver_arg is resolver
+        return 11.0 if leaflet == "in" else 13.0
+
+    monkeypatch.setattr(smooth_in._utils, "_resolve_smoothness_rigidity", fake_rigidity)
+
+    assert smooth_in._resolve_smoothness_rigidity(resolver) == pytest.approx(11.0)
+    assert smooth_out._resolve_smoothness_rigidity(resolver) == pytest.approx(13.0)
+
+
+def test_minimizer_evaluation_manager_bridge_syncs_mutable_state() -> None:
+    mesh = _single_vertex_mesh()
+    minim = Minimizer(
+        mesh,
+        mesh.global_parameters,
+        GradientDescent(),
+        EnergyModuleManager([]),
+        ConstraintModuleManager([]),
+        quiet=True,
+    )
+
+    assert hasattr(minim, "_evaluation_manager")
+    new_mesh = _single_vertex_mesh()
+    modules = [object()]
+    names = ["manual"]
+
+    minim.mesh = new_mesh
+    minim.energy_modules = modules
+    minim.energy_module_names = names
+    minim._sync_evaluation_manager()
+
+    assert minim._evaluation_manager.mesh is new_mesh
+    assert minim._evaluation_manager.global_params is minim.global_params
+    assert minim._evaluation_manager.param_resolver is minim.param_resolver
+    assert minim._evaluation_manager.energy_modules is modules
+    assert minim._evaluation_manager.energy_module_names is names


### PR DESCRIPTION
## Summary

Repair the regressions introduced by PR527 while keeping the harmless cleanup pieces:

- restore PR526 `Minimizer` behavior and add `EvaluationManager` only as a synced bridge
- restore compatibility shims on the tilt magnitude/smoothness front modules
- fix strict/non-strict Fortran kernel dispatch without changing global mesh cache layout
- add regression tests for refactor compatibility and strict nocopy curvature dispatch

## Why

PR527 was merged without passing CI and its broad `Minimizer` delegation changed termination, constraint enforcement, volume preservation, auto-repair, and debug logging semantics. This PR restores the proven minimizer behavior while preserving the refactor boundary needed for a later, safer `EvaluationManager` migration.

## Validation

- User ran: `pytest -q` and reported all green
- `pytest -q tests/test_refactor_compatibility.py tests/test_tilt_leaflet_pure.py tests/test_tilt_only_energy_skips_non_tilt_unit.py tests/test_curvature_kernel_optional_outputs_unit.py tests/test_fortran_kernels.py tests/test_minimizer.py tests/test_tilt_validation.py` - 59 passed
- Pre-commit hooks passed during commit
