### PR TITLE
refactor: delegate single-tilt evaluation paths

### DIFF
--- a/runtime/evaluation_manager.py
+++ b/runtime/evaluation_manager.py
@@ -234,25 +234,60 @@ class EvaluationManager:
         grad_dummy = np.zeros_like(positions)
         total_energy = 0.0
 
-        for name, module in zip(self.energy_module_names, self.energy_modules):
+        module_names = self.energy_module_names
+        if len(module_names) != len(self.energy_modules):
+            module_names = [
+                getattr(module, "__name__", module.__class__.__name__)
+                for module in self.energy_modules
+            ]
+
+        for name, module in zip(module_names, self.energy_modules):
             scale = self.experimental_energy_scale_fn(str(name))
             if not getattr(module, "USES_TILT", False):
                 continue
             if hasattr(module, "compute_energy_array"):
-                E_mod = self._call_module_energy_array(
-                    module, positions=positions, index_map=index_map, tilts=tilts
-                )
+                try:
+                    E_mod = self._call_module_energy_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                        tilts=tilts,
+                    )
+                except TypeError:
+                    E_mod = self._call_module_energy_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                    )
                 total_energy += float(scale) * float(E_mod)
                 continue
 
             if hasattr(module, "compute_energy_and_gradient_array"):
-                E_mod = self._call_module_array(
-                    module,
-                    positions=positions,
-                    index_map=index_map,
-                    grad_arr=grad_dummy,
-                    tilts=tilts,
-                )
+                try:
+                    E_mod = self._call_module_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                        grad_arr=grad_dummy,
+                        tilts=tilts,
+                        tilt_grad_arr=None,
+                    )
+                except TypeError:
+                    try:
+                        E_mod = self._call_module_array(
+                            module,
+                            positions=positions,
+                            index_map=index_map,
+                            grad_arr=grad_dummy,
+                            tilts=tilts,
+                        )
+                    except TypeError:
+                        E_mod = self._call_module_array(
+                            module,
+                            positions=positions,
+                            index_map=index_map,
+                            grad_arr=grad_dummy,
+                        )
                 total_energy += float(scale) * float(E_mod)
                 continue
 
@@ -284,7 +319,14 @@ class EvaluationManager:
         tilt_grad_arr.fill(0.0)
         total_energy = 0.0
 
-        for name, module in zip(self.energy_module_names, self.energy_modules):
+        module_names = self.energy_module_names
+        if len(module_names) != len(self.energy_modules):
+            module_names = [
+                getattr(module, "__name__", module.__class__.__name__)
+                for module in self.energy_modules
+            ]
+
+        for name, module in zip(module_names, self.energy_modules):
             scale = self.experimental_energy_scale_fn(str(name))
             if not getattr(module, "USES_TILT", False):
                 continue
@@ -293,14 +335,31 @@ class EvaluationManager:
                 if abs(float(scale) - 1.0) > 1.0e-15:
                     grad_before = tilt_grad_arr.copy()
 
-                E_mod = self._call_module_array(
-                    module,
-                    positions=positions,
-                    index_map=index_map,
-                    grad_arr=grad_dummy,
-                    tilts=tilts,
-                    tilt_grad_arr=tilt_grad_arr,
-                )
+                try:
+                    E_mod = self._call_module_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                        grad_arr=grad_dummy,
+                        tilts=tilts,
+                        tilt_grad_arr=tilt_grad_arr,
+                    )
+                except TypeError:
+                    try:
+                        E_mod = self._call_module_array(
+                            module,
+                            positions=positions,
+                            index_map=index_map,
+                            grad_arr=grad_dummy,
+                            tilts=tilts,
+                        )
+                    except TypeError:
+                        E_mod = self._call_module_array(
+                            module,
+                            positions=positions,
+                            index_map=index_map,
+                            grad_arr=grad_dummy,
+                        )
 
                 if grad_before is not None:
                     grad_delta = tilt_grad_arr - grad_before
@@ -311,6 +370,10 @@ class EvaluationManager:
             res = module.compute_energy_and_gradient(
                 self.mesh, self.global_params, self.param_resolver
             )
+            if not isinstance(res, tuple) or len(res) < 2:
+                raise ValueError(
+                    f"Unexpected return from energy module {module}: {res!r}"
+                )
             total_energy += float(scale) * float(res[0])
             if len(res) >= 3 and res[2] is not None:
                 g_tilt = res[2]

--- a/runtime/minimizer.py
+++ b/runtime/minimizer.py
@@ -745,86 +745,11 @@ class Minimizer:
         Uses the array API when available and passes ``tilts`` opportunistically
         (falling back when a module does not accept tilt arguments).
         """
-        index_map = self.mesh.vertex_index_to_row
-        grad_dummy = np.zeros_like(positions)
-        total_energy = 0.0
-
-        module_names = self.energy_module_names
-        if len(module_names) != len(self.energy_modules):
-            module_names = [
-                getattr(module, "__name__", module.__class__.__name__)
-                for module in self.energy_modules
-            ]
-
-        for name, module in zip(module_names, self.energy_modules):
-            scale = self._experimental_energy_scale_for_module(str(name))
-            if not getattr(module, "USES_TILT", False):
-                continue
-            if hasattr(module, "compute_energy_array"):
-                try:
-                    E_mod = module.compute_energy_array(
-                        self.mesh,
-                        self.global_params,
-                        self.param_resolver,
-                        positions=positions,
-                        index_map=index_map,
-                        tilts=tilts,
-                    )
-                except TypeError:
-                    E_mod = module.compute_energy_array(
-                        self.mesh,
-                        self.global_params,
-                        self.param_resolver,
-                        positions=positions,
-                        index_map=index_map,
-                    )
-                total_energy += float(scale) * float(E_mod)
-                continue
-
-            if hasattr(module, "compute_energy_and_gradient_array"):
-                try:
-                    E_mod = self._call_module_array(
-                        module,
-                        positions=positions,
-                        index_map=index_map,
-                        grad_arr=grad_dummy,
-                        tilts=tilts,
-                        tilt_grad_arr=None,
-                    )
-                except TypeError:
-                    try:
-                        E_mod = self._call_module_array(
-                            module,
-                            positions=positions,
-                            index_map=index_map,
-                            grad_arr=grad_dummy,
-                            tilts=tilts,
-                        )
-                    except TypeError:
-                        E_mod = self._call_module_array(
-                            module,
-                            positions=positions,
-                            index_map=index_map,
-                            grad_arr=grad_dummy,
-                        )
-                total_energy += float(scale) * float(E_mod)
-                continue
-
-            # Legacy dict modules (typically tilt-independent): energy-only path.
-            try:
-                E_mod, _ = module.compute_energy_and_gradient(
-                    self.mesh,
-                    self.global_params,
-                    self.param_resolver,
-                    compute_gradient=False,
-                )
-            except TypeError:
-                E_mod, _ = module.compute_energy_and_gradient(
-                    self.mesh, self.global_params, self.param_resolver
-                )
-            total_energy += float(scale) * float(E_mod)
-
-        return float(total_energy)
+        self._sync_evaluation_manager()
+        return self._evaluation_manager.compute_energy_array_with_tilts(
+            positions=positions,
+            tilts=tilts,
+        )
 
     def _compute_energy_and_tilt_gradient_array(
         self,
@@ -834,76 +759,12 @@ class Minimizer:
         tilt_grad_arr: np.ndarray,
     ) -> float:
         """Compute tilt-dependent energy and accumulate dense tilt gradient."""
-        index_map = self.mesh.vertex_index_to_row
-        grad_dummy = np.zeros_like(positions)
-        tilt_grad_arr.fill(0.0)
-        total_energy = 0.0
-
-        module_names = self.energy_module_names
-        if len(module_names) != len(self.energy_modules):
-            module_names = [
-                getattr(module, "__name__", module.__class__.__name__)
-                for module in self.energy_modules
-            ]
-
-        for name, module in zip(module_names, self.energy_modules):
-            scale = self._experimental_energy_scale_for_module(str(name))
-            if not getattr(module, "USES_TILT", False):
-                continue
-            if hasattr(module, "compute_energy_and_gradient_array"):
-                grad_before = None
-                if abs(float(scale) - 1.0) > 1.0e-15:
-                    grad_before = tilt_grad_arr.copy()
-                try:
-                    E_mod = self._call_module_array(
-                        module,
-                        positions=positions,
-                        index_map=index_map,
-                        grad_arr=grad_dummy,
-                        tilts=tilts,
-                        tilt_grad_arr=tilt_grad_arr,
-                    )
-                except TypeError:
-                    try:
-                        E_mod = self._call_module_array(
-                            module,
-                            positions=positions,
-                            index_map=index_map,
-                            grad_arr=grad_dummy,
-                            tilts=tilts,
-                        )
-                    except TypeError:
-                        E_mod = self._call_module_array(
-                            module,
-                            positions=positions,
-                            index_map=index_map,
-                            grad_arr=grad_dummy,
-                        )
-                if grad_before is not None:
-                    grad_delta = tilt_grad_arr - grad_before
-                    tilt_grad_arr[:] = grad_before + (float(scale) * grad_delta)
-                total_energy += float(scale) * float(E_mod)
-                continue
-
-            # Dict fallback: accept modules that optionally return a tilt gradient.
-            res = module.compute_energy_and_gradient(
-                self.mesh, self.global_params, self.param_resolver
-            )
-
-            if not isinstance(res, tuple) or len(res) < 2:
-                raise ValueError(
-                    f"Unexpected return from energy module {module}: {res!r}"
-                )
-
-            total_energy += float(scale) * float(res[0])
-            if len(res) >= 3 and res[2] is not None:
-                g_tilt = res[2]
-                for vidx, gvec in g_tilt.items():
-                    row = index_map.get(int(vidx))
-                    if row is not None:
-                        tilt_grad_arr[row] += float(scale) * gvec
-
-        return float(total_energy)
+        self._sync_evaluation_manager()
+        return self._evaluation_manager.compute_energy_and_tilt_gradient_array(
+            positions=positions,
+            tilts=tilts,
+            tilt_grad_arr=tilt_grad_arr,
+        )
 
     def _compute_energy_array_with_leaflet_tilts(
         self,

--- a/tests/test_refactor_compatibility.py
+++ b/tests/test_refactor_compatibility.py
@@ -25,6 +25,61 @@ def _single_vertex_mesh() -> Mesh:
     return mesh
 
 
+class _SingleTiltEnergyModule:
+    USES_TILT = True
+
+    def compute_energy_and_gradient_array(
+        self,
+        mesh,
+        global_params,
+        param_resolver,
+        *,
+        positions,
+        index_map,
+        grad_arr,
+        tilts=None,
+    ) -> float:
+        _ = mesh, global_params, param_resolver, positions, index_map, grad_arr
+        return float(np.sum(np.asarray(tilts, dtype=float)))
+
+
+class _SingleTiltGradientModule:
+    USES_TILT = True
+
+    def compute_energy_and_gradient_array(
+        self,
+        mesh,
+        global_params,
+        param_resolver,
+        *,
+        positions,
+        index_map,
+        grad_arr,
+        tilts=None,
+        tilt_grad_arr=None,
+    ) -> float:
+        _ = mesh, global_params, param_resolver, positions, index_map, grad_arr
+        tilts = np.asarray(tilts, dtype=float)
+        if tilt_grad_arr is not None:
+            tilt_grad_arr += tilts
+        return float(np.sum(tilts))
+
+
+class _NonTiltEnergyModule:
+    def compute_energy_and_gradient_array(
+        self,
+        mesh,
+        global_params,
+        param_resolver,
+        *,
+        positions,
+        index_map,
+        grad_arr,
+    ) -> float:
+        _ = mesh, global_params, param_resolver, positions, index_map, grad_arr
+        return 100.0
+
+
 def test_tilt_front_modules_keep_legacy_helper_shims(monkeypatch) -> None:
     tilt_in = importlib.import_module("modules.energy.tilt_in")
     tilt_out = importlib.import_module("modules.energy.tilt_out")
@@ -104,3 +159,53 @@ def test_minimizer_evaluation_manager_bridge_syncs_mutable_state() -> None:
     assert minim._evaluation_manager.param_resolver is minim.param_resolver
     assert minim._evaluation_manager.energy_modules is modules
     assert minim._evaluation_manager.energy_module_names is names
+
+
+def test_minimizer_delegates_single_tilt_energy_path_with_sync() -> None:
+    mesh = _single_vertex_mesh()
+    minim = Minimizer(
+        mesh,
+        mesh.global_parameters,
+        GradientDescent(),
+        EnergyModuleManager([]),
+        ConstraintModuleManager([]),
+        quiet=True,
+    )
+    minim.energy_modules = [_NonTiltEnergyModule(), _SingleTiltEnergyModule()]
+    minim.energy_module_names = ["non_tilt", "tilt"]
+
+    tilts = np.asarray([[1.0, 2.0, 3.0]], dtype=float)
+    energy = minim._compute_energy_array_with_tilts(
+        positions=mesh.positions_view(),
+        tilts=tilts,
+    )
+
+    assert energy == pytest.approx(6.0)
+    assert minim._evaluation_manager.energy_modules is minim.energy_modules
+    assert minim._evaluation_manager.energy_module_names is minim.energy_module_names
+
+
+def test_minimizer_delegates_single_tilt_gradient_path_with_sync() -> None:
+    mesh = _single_vertex_mesh()
+    minim = Minimizer(
+        mesh,
+        mesh.global_parameters,
+        GradientDescent(),
+        EnergyModuleManager([]),
+        ConstraintModuleManager([]),
+        quiet=True,
+    )
+    minim.energy_modules = [_NonTiltEnergyModule(), _SingleTiltGradientModule()]
+    minim.energy_module_names = ["non_tilt", "tilt"]
+
+    tilts = np.asarray([[1.0, 2.0, 3.0]], dtype=float)
+    tilt_grad = np.zeros_like(tilts)
+    energy = minim._compute_energy_and_tilt_gradient_array(
+        positions=mesh.positions_view(),
+        tilts=tilts,
+        tilt_grad_arr=tilt_grad,
+    )
+
+    assert energy == pytest.approx(6.0)
+    np.testing.assert_allclose(tilt_grad, tilts)
+    assert minim._evaluation_manager.energy_modules is minim.energy_modules


### PR DESCRIPTION
## Summary

Migrate the first narrow evaluation slice from `Minimizer` into `EvaluationManager`:

- delegate `_compute_energy_array_with_tilts` through the synced evaluation manager
- delegate `_compute_energy_and_tilt_gradient_array` through the synced evaluation manager
- move the minimizer's fallback behavior for single-tilt modules into `EvaluationManager`
- add regression coverage proving direct minimizer mutations are synced before delegation

## Why

PR528 restored `EvaluationManager` as a bridge but intentionally avoided broad delegation. This PR resumes the migration one path at a time, limited to the single-tilt energy/gradient path covered by focused parity tests.

## Validation

- `pytest -q tests/test_refactor_compatibility.py tests/test_tilt_only_energy_skips_non_tilt_unit.py tests/test_minimizer.py tests/test_tilt_validation.py` - 31 passed
- `pytest -q tests/test_tilt_leaflet_pure.py tests/test_curvature_kernel_optional_outputs_unit.py tests/test_fortran_kernels.py tests/test_preconditioners.py tests/test_bt_utils.py tests/test_bt_selection.py tests/test_bt_transition.py tests/test_bt_divergence.py tests/test_entities_reexports.py` - 49 passed
- `pytest -q tests/test_bending_tilt_leaflet_energy.py tests/test_bending_tilt_leaflet_e2e.py tests/test_bending_energy.py tests/test_bending_finite_difference.py tests/test_rim_slope_match_out.py tests/test_tilt_leaflet_smoothness.py` - 20 passed, 2 deselected
- Pre-commit hooks passed during commit
