### PR TITLE
refactor: delegate total energy evaluation paths

### DIFF
--- a/runtime/evaluation_manager.py
+++ b/runtime/evaluation_manager.py
@@ -190,21 +190,48 @@ class EvaluationManager:
         for name, module in zip(self.energy_module_names, self.energy_modules):
             scale = self.experimental_energy_scale_fn(str(name))
             if hasattr(module, "compute_energy_array"):
-                E_mod = self._call_module_energy_array(
-                    module, positions=positions, index_map=index_map, tilts=tilts
-                )
+                kwargs = {"positions": positions, "index_map": index_map}
+                if getattr(module, "USES_TILT", False):
+                    kwargs["tilts"] = tilts
+                E_mod = self._call_module_energy_array(module, **kwargs)
                 total_energy += float(scale) * self._coerce_energy_value(E_mod)
                 continue
 
             if hasattr(module, "compute_energy_and_gradient_array"):
                 grad_dummy.fill(0.0)
-                E_mod = self._call_module_array(
-                    module,
-                    positions=positions,
-                    index_map=index_map,
-                    grad_arr=grad_dummy,
-                    tilts=tilts,
-                )
+                if getattr(module, "USES_TILT", False):
+                    try:
+                        E_mod = self._call_module_array(
+                            module,
+                            positions=positions,
+                            index_map=index_map,
+                            grad_arr=grad_dummy,
+                            tilts=tilts,
+                            tilt_grad_arr=None,
+                        )
+                    except TypeError:
+                        try:
+                            E_mod = self._call_module_array(
+                                module,
+                                positions=positions,
+                                index_map=index_map,
+                                grad_arr=grad_dummy,
+                                tilts=tilts,
+                            )
+                        except TypeError:
+                            E_mod = self._call_module_array(
+                                module,
+                                positions=positions,
+                                index_map=index_map,
+                                grad_arr=grad_dummy,
+                            )
+                else:
+                    E_mod = self._call_module_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                        grad_arr=grad_dummy,
+                    )
                 total_energy += float(scale) * self._coerce_energy_value(E_mod)
                 continue
 

--- a/runtime/minimizer.py
+++ b/runtime/minimizer.py
@@ -625,43 +625,8 @@ class Minimizer:
 
     def _compute_energy_array_total(self, *, positions: np.ndarray) -> float:
         """Compute total energy for fixed positions and the current mesh tilt state."""
-        index_map = self.mesh.vertex_index_to_row
-        grad_dummy = self.energy_context().scratch_array(
-            "energy_only_grad_dummy", shape=positions.shape, dtype=positions.dtype
-        )
-        total_energy = 0.0
-
-        for name, module in zip(self.energy_module_names, self.energy_modules):
-            scale = self._experimental_energy_scale_for_module(str(name))
-            if hasattr(module, "compute_energy_array"):
-                E_mod = self._call_module_energy_array(
-                    module,
-                    positions=positions,
-                    index_map=index_map,
-                )
-                total_energy += float(scale) * self._coerce_energy_value(E_mod)
-                continue
-
-            if hasattr(module, "compute_energy_and_gradient_array"):
-                grad_dummy.fill(0.0)
-                E_mod = self._call_module_array(
-                    module,
-                    positions=positions,
-                    index_map=index_map,
-                    grad_arr=grad_dummy,
-                )
-                total_energy += float(scale) * self._coerce_energy_value(E_mod)
-                continue
-
-            E_mod, _ = module.compute_energy_and_gradient(
-                self.mesh,
-                self.global_params,
-                self.param_resolver,
-                compute_gradient=False,
-            )
-            total_energy += float(scale) * self._coerce_energy_value(E_mod)
-
-        return float(total_energy)
+        self._sync_evaluation_manager()
+        return self._evaluation_manager.compute_energy_array_total(positions=positions)
 
     def _compute_total_energy_array_with_tilts(
         self,
@@ -670,69 +635,11 @@ class Minimizer:
         tilts: np.ndarray,
     ) -> float:
         """Compute total energy for fixed positions and a projected tilt field."""
-        index_map = self.mesh.vertex_index_to_row
-        grad_dummy = self.energy_context().scratch_array(
-            "energy_only_tilt_grad_dummy", shape=positions.shape, dtype=positions.dtype
+        self._sync_evaluation_manager()
+        return self._evaluation_manager.compute_total_energy_array_with_tilts(
+            positions=positions,
+            tilts=tilts,
         )
-        total_energy = 0.0
-
-        for name, module in zip(self.energy_module_names, self.energy_modules):
-            scale = self._experimental_energy_scale_for_module(str(name))
-            if hasattr(module, "compute_energy_array"):
-                kwargs = {"positions": positions, "index_map": index_map}
-                if getattr(module, "USES_TILT", False):
-                    kwargs["tilts"] = tilts
-                E_mod = self._call_module_energy_array(module, **kwargs)
-                total_energy += float(scale) * self._coerce_energy_value(E_mod)
-                continue
-
-            if hasattr(module, "compute_energy_and_gradient_array"):
-                grad_dummy.fill(0.0)
-                if getattr(module, "USES_TILT", False):
-                    try:
-                        E_mod = self._call_module_array(
-                            module,
-                            positions=positions,
-                            index_map=index_map,
-                            grad_arr=grad_dummy,
-                            tilts=tilts,
-                            tilt_grad_arr=None,
-                        )
-                    except TypeError:
-                        try:
-                            E_mod = self._call_module_array(
-                                module,
-                                positions=positions,
-                                index_map=index_map,
-                                grad_arr=grad_dummy,
-                                tilts=tilts,
-                            )
-                        except TypeError:
-                            E_mod = self._call_module_array(
-                                module,
-                                positions=positions,
-                                index_map=index_map,
-                                grad_arr=grad_dummy,
-                            )
-                else:
-                    E_mod = self._call_module_array(
-                        module,
-                        positions=positions,
-                        index_map=index_map,
-                        grad_arr=grad_dummy,
-                    )
-                total_energy += float(scale) * self._coerce_energy_value(E_mod)
-                continue
-
-            E_mod, _ = module.compute_energy_and_gradient(
-                self.mesh,
-                self.global_params,
-                self.param_resolver,
-                compute_gradient=False,
-            )
-            total_energy += float(scale) * self._coerce_energy_value(E_mod)
-
-        return float(total_energy)
 
     def _compute_energy_array_with_tilts(
         self,

--- a/tests/test_refactor_compatibility.py
+++ b/tests/test_refactor_compatibility.py
@@ -65,6 +65,23 @@ class _SingleTiltGradientModule:
         return float(np.sum(tilts))
 
 
+class _SingleTiltEnergyArrayModule:
+    USES_TILT = True
+
+    def compute_energy_array(
+        self,
+        mesh,
+        global_params,
+        param_resolver,
+        *,
+        positions,
+        index_map,
+        tilts=None,
+    ) -> float:
+        _ = mesh, global_params, param_resolver, positions, index_map
+        return float(np.sum(np.asarray(tilts, dtype=float)))
+
+
 class _NonTiltEnergyModule:
     def compute_energy_and_gradient_array(
         self,
@@ -78,6 +95,36 @@ class _NonTiltEnergyModule:
     ) -> float:
         _ = mesh, global_params, param_resolver, positions, index_map, grad_arr
         return 100.0
+
+
+class _NonTiltEnergyArrayRejectsTiltsModule:
+    def compute_energy_array(
+        self,
+        mesh,
+        global_params,
+        param_resolver,
+        *,
+        positions,
+        index_map,
+    ) -> float:
+        _ = mesh, global_params, param_resolver, positions, index_map
+        return 40.0
+
+
+class _ShapeEnergyGradientModule:
+    def compute_energy_and_gradient_array(
+        self,
+        mesh,
+        global_params,
+        param_resolver,
+        *,
+        positions,
+        index_map,
+        grad_arr,
+    ) -> float:
+        _ = mesh, global_params, param_resolver, positions, index_map
+        grad_arr += 1.0
+        return 2.0
 
 
 def test_tilt_front_modules_keep_legacy_helper_shims(monkeypatch) -> None:
@@ -183,6 +230,56 @@ def test_minimizer_delegates_single_tilt_energy_path_with_sync() -> None:
     assert energy == pytest.approx(6.0)
     assert minim._evaluation_manager.energy_modules is minim.energy_modules
     assert minim._evaluation_manager.energy_module_names is minim.energy_module_names
+
+
+def test_minimizer_delegates_total_energy_path_with_sync() -> None:
+    mesh = _single_vertex_mesh()
+    minim = Minimizer(
+        mesh,
+        mesh.global_parameters,
+        GradientDescent(),
+        EnergyModuleManager([]),
+        ConstraintModuleManager([]),
+        quiet=True,
+    )
+    minim.energy_modules = [
+        _NonTiltEnergyArrayRejectsTiltsModule(),
+        _ShapeEnergyGradientModule(),
+    ]
+    minim.energy_module_names = ["array", "gradient"]
+
+    energy = minim._compute_energy_array_total(positions=mesh.positions_view())
+
+    assert energy == pytest.approx(42.0)
+    assert minim._evaluation_manager.energy_modules is minim.energy_modules
+    assert minim._evaluation_manager.energy_module_names is minim.energy_module_names
+
+
+def test_minimizer_delegates_total_energy_with_projected_tilts_path() -> None:
+    mesh = _single_vertex_mesh()
+    minim = Minimizer(
+        mesh,
+        mesh.global_parameters,
+        GradientDescent(),
+        EnergyModuleManager([]),
+        ConstraintModuleManager([]),
+        quiet=True,
+    )
+    minim.energy_modules = [
+        _NonTiltEnergyArrayRejectsTiltsModule(),
+        _SingleTiltEnergyArrayModule(),
+        _SingleTiltGradientModule(),
+    ]
+    minim.energy_module_names = ["non_tilt", "tilt_array", "tilt_gradient"]
+
+    tilts = np.asarray([[1.0, 2.0, 3.0]], dtype=float)
+    energy = minim._compute_total_energy_array_with_tilts(
+        positions=mesh.positions_view(),
+        tilts=tilts,
+    )
+
+    assert energy == pytest.approx(52.0)
+    assert minim._evaluation_manager.energy_modules is minim.energy_modules
 
 
 def test_minimizer_delegates_single_tilt_gradient_path_with_sync() -> None:


### PR DESCRIPTION
## Summary

Migrate the next narrow evaluation slice from `Minimizer` into `EvaluationManager`:

- delegate `_compute_energy_array_total` through the synced evaluation manager
- delegate `_compute_total_energy_array_with_tilts` through the synced evaluation manager
- preserve projected-tilt behavior so only `USES_TILT` modules receive trial tilt arrays
- add regression coverage for all-module totals and projected-tilt total energy

## Why

PR529 moved the single-tilt paths safely. This PR continues the migration one slice at a time, keeping optimizer orchestration, constraints, volume enforcement, line search, thetaB, and auto-repair in `Minimizer`.

## Validation

- `pytest -q tests/test_refactor_compatibility.py tests/test_tilt_only_energy_skips_non_tilt_unit.py tests/test_minimizer.py tests/test_tilt_validation.py` - 33 passed
- `pytest -q tests/test_tilt_leaflet_pure.py tests/test_curvature_kernel_optional_outputs_unit.py tests/test_fortran_kernels.py tests/test_preconditioners.py tests/test_bt_utils.py tests/test_bt_selection.py tests/test_bt_transition.py tests/test_bt_divergence.py tests/test_entities_reexports.py` - 49 passed
- `pytest -q tests/test_bending_tilt_leaflet_energy.py tests/test_bending_tilt_leaflet_e2e.py tests/test_bending_energy.py tests/test_bending_finite_difference.py tests/test_rim_slope_match_out.py tests/test_tilt_leaflet_smoothness.py` - 20 passed, 2 deselected
- Pre-commit hooks passed during commit
