### PR TITLE
refactor: delegate leaflet energy evaluation paths

### DIFF
--- a/runtime/evaluation_manager.py
+++ b/runtime/evaluation_manager.py
@@ -430,25 +430,42 @@ class EvaluationManager:
         for name, module in zip(self.energy_module_names, self.energy_modules):
             scale = self.experimental_energy_scale_fn(str(name))
             if hasattr(module, "compute_energy_array"):
-                E_mod = self._call_module_energy_array(
-                    module,
-                    positions=positions,
-                    index_map=index_map,
-                    tilts_in=tilts_in,
-                    tilts_out=tilts_out,
-                )
+                try:
+                    E_mod = self._call_module_energy_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                        tilts_in=tilts_in,
+                        tilts_out=tilts_out,
+                    )
+                except TypeError:
+                    E_mod = self._call_module_energy_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                    )
                 total_energy += float(scale) * float(E_mod)
                 continue
 
             if hasattr(module, "compute_energy_and_gradient_array"):
-                E_mod = self._call_module_array(
-                    module,
-                    positions=positions,
-                    index_map=index_map,
-                    grad_arr=grad_dummy,
-                    tilts_in=tilts_in,
-                    tilts_out=tilts_out,
-                )
+                try:
+                    E_mod = self._call_module_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                        grad_arr=grad_dummy,
+                        tilts_in=tilts_in,
+                        tilts_out=tilts_out,
+                        tilt_in_grad_arr=None,
+                        tilt_out_grad_arr=None,
+                    )
+                except TypeError:
+                    E_mod = self._call_module_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                        grad_arr=grad_dummy,
+                    )
                 total_energy += float(scale) * float(E_mod)
                 continue
 
@@ -490,23 +507,63 @@ class EvaluationManager:
             if not getattr(module, "USES_TILT_LEAFLETS", False):
                 continue
 
-            kwargs = {
-                "positions": positions,
-                "index_map": index_map,
-                "tilts_in": tilts_in,
-                "tilts_out": tilts_out,
-                "tilt_vertex_areas_in": tilt_vertex_areas_in,
-                "tilt_vertex_areas_out": tilt_vertex_areas_out,
-            }
+            # Fast path for pure tilt magnitude penalties.
+            if name == "tilt_in" and tilt_vertex_areas_in is not None:
+                k_tilt = float(self.param_resolver.get(None, "tilt_modulus_in") or 0.0)
+                if k_tilt != 0.0:
+                    sq = np.einsum("ij,ij->i", tilts_in, tilts_in)
+                    total_energy += float(
+                        float(scale) * 0.5 * k_tilt * np.sum(sq * tilt_vertex_areas_in)
+                    )
+                continue
+            if name == "tilt_out" and tilt_vertex_areas_out is not None:
+                k_tilt = float(self.param_resolver.get(None, "tilt_modulus_out") or 0.0)
+                if k_tilt != 0.0:
+                    sq = np.einsum("ij,ij->i", tilts_out, tilts_out)
+                    total_energy += float(
+                        float(scale) * 0.5 * k_tilt * np.sum(sq * tilt_vertex_areas_out)
+                    )
+                continue
 
             if hasattr(module, "compute_energy_array"):
-                E_mod = self._call_module_energy_array(module, **kwargs)
+                try:
+                    E_mod = self._call_module_energy_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                        tilts_in=tilts_in,
+                        tilts_out=tilts_out,
+                    )
+                except TypeError:
+                    # Some tilt modules ignore passed tilts and read from mesh.
+                    E_mod = self._call_module_energy_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                    )
                 total_energy += float(scale) * float(E_mod)
                 continue
 
             if hasattr(module, "compute_energy_and_gradient_array"):
-                kwargs["grad_arr"] = None
-                E_mod = self._call_module_array(module, **kwargs)
+                try:
+                    E_mod = self._call_module_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                        grad_arr=None,
+                        tilts_in=tilts_in,
+                        tilts_out=tilts_out,
+                        tilt_in_grad_arr=None,
+                        tilt_out_grad_arr=None,
+                    )
+                except TypeError:
+                    # Some tilt modules ignore passed tilts and read from mesh.
+                    E_mod = self._call_module_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                        grad_arr=None,
+                    )
                 total_energy += float(scale) * float(E_mod)
                 continue
 

--- a/runtime/minimizer.py
+++ b/runtime/minimizer.py
@@ -682,73 +682,13 @@ class Minimizer:
         grad_dummy: np.ndarray | None = None,
     ) -> float:
         """Compute total energy for fixed positions and leaflet tilt arrays."""
-        index_map = self.mesh.vertex_index_to_row
-        if grad_dummy is None:
-            grad_dummy = np.zeros_like(positions)
-        else:
-            grad_dummy.fill(0.0)
-        total_energy = 0.0
-
-        for name, module in zip(self.energy_module_names, self.energy_modules):
-            scale = self._experimental_energy_scale_for_module(str(name))
-            if hasattr(module, "compute_energy_array"):
-                try:
-                    E_mod = module.compute_energy_array(
-                        self.mesh,
-                        self.global_params,
-                        self.param_resolver,
-                        positions=positions,
-                        index_map=index_map,
-                        tilts_in=tilts_in,
-                        tilts_out=tilts_out,
-                    )
-                except TypeError:
-                    E_mod = module.compute_energy_array(
-                        self.mesh,
-                        self.global_params,
-                        self.param_resolver,
-                        positions=positions,
-                        index_map=index_map,
-                    )
-                total_energy += float(scale) * float(E_mod)
-                continue
-
-            if hasattr(module, "compute_energy_and_gradient_array"):
-                try:
-                    E_mod = self._call_module_array(
-                        module,
-                        positions=positions,
-                        index_map=index_map,
-                        grad_arr=grad_dummy,
-                        tilts_in=tilts_in,
-                        tilts_out=tilts_out,
-                        tilt_in_grad_arr=None,
-                        tilt_out_grad_arr=None,
-                    )
-                except TypeError:
-                    E_mod = self._call_module_array(
-                        module,
-                        positions=positions,
-                        index_map=index_map,
-                        grad_arr=grad_dummy,
-                    )
-                total_energy += float(scale) * float(E_mod)
-                continue
-
-            try:
-                E_mod, _ = module.compute_energy_and_gradient(
-                    self.mesh,
-                    self.global_params,
-                    self.param_resolver,
-                    compute_gradient=False,
-                )
-            except TypeError:
-                E_mod, _ = module.compute_energy_and_gradient(
-                    self.mesh, self.global_params, self.param_resolver
-                )
-            total_energy += float(scale) * float(E_mod)
-
-        return float(total_energy)
+        self._sync_evaluation_manager()
+        return self._evaluation_manager.compute_energy_array_with_leaflet_tilts(
+            positions=positions,
+            tilts_in=tilts_in,
+            tilts_out=tilts_out,
+            grad_dummy=grad_dummy,
+        )
 
     def _compute_tilt_dependent_energy_with_leaflet_tilts(
         self,
@@ -766,89 +706,17 @@ class Minimizer:
         are constant when positions are frozen, so dropping them preserves
         backtracking accept/reject decisions while avoiding extra work.
         """
-        index_map = self.mesh.vertex_index_to_row
-        if grad_dummy is None:
-            grad_dummy = np.zeros_like(positions)
-        else:
-            grad_dummy.fill(0.0)
-        total_energy = 0.0
-
-        for name, module in zip(self.energy_module_names, self.energy_modules):
-            scale = self._experimental_energy_scale_for_module(str(name))
-            if not getattr(module, "USES_TILT_LEAFLETS", False):
-                continue
-
-            # Fast path for pure tilt magnitude penalties.
-            if name == "tilt_in" and tilt_vertex_areas_in is not None:
-                k_tilt = float(self.param_resolver.get(None, "tilt_modulus_in") or 0.0)
-                if k_tilt != 0.0:
-                    sq = np.einsum("ij,ij->i", tilts_in, tilts_in)
-                    total_energy += float(
-                        float(scale) * 0.5 * k_tilt * np.sum(sq * tilt_vertex_areas_in)
-                    )
-                continue
-            if name == "tilt_out" and tilt_vertex_areas_out is not None:
-                k_tilt = float(self.param_resolver.get(None, "tilt_modulus_out") or 0.0)
-                if k_tilt != 0.0:
-                    sq = np.einsum("ij,ij->i", tilts_out, tilts_out)
-                    total_energy += float(
-                        float(scale) * 0.5 * k_tilt * np.sum(sq * tilt_vertex_areas_out)
-                    )
-                continue
-
-            if hasattr(module, "compute_energy_array"):
-                try:
-                    E_mod = self._call_module_energy_array(
-                        module,
-                        positions=positions,
-                        index_map=index_map,
-                        tilts_in=tilts_in,
-                        tilts_out=tilts_out,
-                    )
-                except TypeError:
-                    # Some tilt modules ignore passed tilts and read from mesh.
-                    E_mod = self._call_module_energy_array(
-                        module,
-                        positions=positions,
-                        index_map=index_map,
-                    )
-                total_energy += float(scale) * float(E_mod)
-                continue
-
-            if hasattr(module, "compute_energy_and_gradient_array"):
-                try:
-                    E_mod = self._call_module_array(
-                        module,
-                        positions=positions,
-                        index_map=index_map,
-                        grad_arr=None,
-                        tilts_in=tilts_in,
-                        tilts_out=tilts_out,
-                        tilt_in_grad_arr=None,
-                        tilt_out_grad_arr=None,
-                    )
-                except TypeError:
-                    # Some tilt modules ignore passed tilts and read from mesh.
-                    E_mod = self._call_module_array(
-                        module,
-                        positions=positions,
-                        index_map=index_map,
-                        grad_arr=None,
-                    )
-                total_energy += float(scale) * float(E_mod)
-                continue
-
-            # Legacy dict modules are rare here; fall back to full energy.
-            # (Inner-loop performance comes from the array modules.)
-            E_full = self._compute_energy_array_with_leaflet_tilts(
+        self._sync_evaluation_manager()
+        return (
+            self._evaluation_manager.compute_tilt_dependent_energy_with_leaflet_tilts(
                 positions=positions,
                 tilts_in=tilts_in,
                 tilts_out=tilts_out,
                 grad_dummy=grad_dummy,
+                tilt_vertex_areas_in=tilt_vertex_areas_in,
+                tilt_vertex_areas_out=tilt_vertex_areas_out,
             )
-            return float(E_full)
-
-        return float(total_energy)
+        )
 
     def _compute_energy_and_leaflet_tilt_gradients_array(
         self,

--- a/tests/test_refactor_compatibility.py
+++ b/tests/test_refactor_compatibility.py
@@ -127,6 +127,83 @@ class _ShapeEnergyGradientModule:
         return 2.0
 
 
+class _LeafletEnergyArrayModule:
+    USES_TILT_LEAFLETS = True
+
+    def compute_energy_array(
+        self,
+        mesh,
+        global_params,
+        param_resolver,
+        *,
+        positions,
+        index_map,
+        tilts_in=None,
+        tilts_out=None,
+    ) -> float:
+        _ = mesh, global_params, param_resolver, positions, index_map
+        return float(np.sum(tilts_in) + 2.0 * np.sum(tilts_out))
+
+
+class _LeafletGradientEnergyModule:
+    USES_TILT_LEAFLETS = True
+
+    def compute_energy_and_gradient_array(
+        self,
+        mesh,
+        global_params,
+        param_resolver,
+        *,
+        positions,
+        index_map,
+        grad_arr,
+        tilts_in=None,
+        tilts_out=None,
+        tilt_in_grad_arr=None,
+        tilt_out_grad_arr=None,
+    ) -> float:
+        _ = (
+            mesh,
+            global_params,
+            param_resolver,
+            positions,
+            index_map,
+            grad_arr,
+            tilt_in_grad_arr,
+            tilt_out_grad_arr,
+        )
+        return float(3.0 * np.sum(tilts_in) + 5.0 * np.sum(tilts_out))
+
+
+class _LeafletRejectsTrialTiltsModule:
+    USES_TILT_LEAFLETS = True
+
+    def compute_energy_array(
+        self,
+        mesh,
+        global_params,
+        param_resolver,
+        *,
+        positions,
+        index_map,
+        **kwargs,
+    ) -> float:
+        _ = mesh, global_params, param_resolver, positions, index_map
+        if "tilts_in" in kwargs or "tilts_out" in kwargs:
+            raise TypeError("legacy module reads tilts from mesh")
+        return 7.0
+
+
+class _LeafletMarkerModule:
+    USES_TILT_LEAFLETS = True
+
+
+class _NonLeafletExplodingModule:
+    def compute_energy_array(self, *args, **kwargs) -> float:
+        _ = args, kwargs
+        raise AssertionError("non-leaflet module should be skipped")
+
+
 def test_tilt_front_modules_keep_legacy_helper_shims(monkeypatch) -> None:
     tilt_in = importlib.import_module("modules.energy.tilt_in")
     tilt_out = importlib.import_module("modules.energy.tilt_out")
@@ -279,6 +356,95 @@ def test_minimizer_delegates_total_energy_with_projected_tilts_path() -> None:
     )
 
     assert energy == pytest.approx(52.0)
+    assert minim._evaluation_manager.energy_modules is minim.energy_modules
+
+
+def test_minimizer_delegates_leaflet_energy_path_with_legacy_fallback() -> None:
+    mesh = _single_vertex_mesh()
+    minim = Minimizer(
+        mesh,
+        mesh.global_parameters,
+        GradientDescent(),
+        EnergyModuleManager([]),
+        ConstraintModuleManager([]),
+        quiet=True,
+    )
+    minim.energy_modules = [
+        _LeafletRejectsTrialTiltsModule(),
+        _LeafletEnergyArrayModule(),
+        _LeafletGradientEnergyModule(),
+    ]
+    minim.energy_module_names = ["legacy_leaflet", "leaflet_array", "leaflet_gradient"]
+
+    tilts_in = np.asarray([[1.0, 2.0, 3.0]], dtype=float)
+    tilts_out = np.asarray([[4.0, 5.0, 6.0]], dtype=float)
+    energy = minim._compute_energy_array_with_leaflet_tilts(
+        positions=mesh.positions_view(),
+        tilts_in=tilts_in,
+        tilts_out=tilts_out,
+    )
+
+    assert energy == pytest.approx(7.0 + 36.0 + 93.0)
+    assert minim._evaluation_manager.energy_modules is minim.energy_modules
+    assert minim._evaluation_manager.energy_module_names is minim.energy_module_names
+
+
+def test_minimizer_delegates_leaflet_tilt_dependent_fast_paths() -> None:
+    mesh = _single_vertex_mesh()
+    mesh.global_parameters.set("tilt_modulus_in", 2.0)
+    mesh.global_parameters.set("tilt_modulus_out", 3.0)
+    minim = Minimizer(
+        mesh,
+        mesh.global_parameters,
+        GradientDescent(),
+        EnergyModuleManager([]),
+        ConstraintModuleManager([]),
+        quiet=True,
+    )
+    minim.energy_modules = [
+        _NonLeafletExplodingModule(),
+        _LeafletMarkerModule(),
+        _LeafletMarkerModule(),
+    ]
+    minim.energy_module_names = ["shape", "tilt_in", "tilt_out"]
+
+    tilts_in = np.asarray([[1.0, 2.0, 2.0]], dtype=float)
+    tilts_out = np.asarray([[2.0, 0.0, 1.0]], dtype=float)
+    energy = minim._compute_tilt_dependent_energy_with_leaflet_tilts(
+        positions=mesh.positions_view(),
+        tilts_in=tilts_in,
+        tilts_out=tilts_out,
+        tilt_vertex_areas_in=np.asarray([0.5], dtype=float),
+        tilt_vertex_areas_out=np.asarray([2.0], dtype=float),
+    )
+
+    assert energy == pytest.approx(19.5)
+    assert minim._evaluation_manager.energy_modules is minim.energy_modules
+
+
+def test_minimizer_delegates_leaflet_tilt_dependent_legacy_fallback() -> None:
+    mesh = _single_vertex_mesh()
+    minim = Minimizer(
+        mesh,
+        mesh.global_parameters,
+        GradientDescent(),
+        EnergyModuleManager([]),
+        ConstraintModuleManager([]),
+        quiet=True,
+    )
+    minim.energy_modules = [
+        _NonLeafletExplodingModule(),
+        _LeafletRejectsTrialTiltsModule(),
+    ]
+    minim.energy_module_names = ["shape", "legacy_leaflet"]
+
+    energy = minim._compute_tilt_dependent_energy_with_leaflet_tilts(
+        positions=mesh.positions_view(),
+        tilts_in=np.asarray([[1.0, 2.0, 3.0]], dtype=float),
+        tilts_out=np.asarray([[4.0, 5.0, 6.0]], dtype=float),
+    )
+
+    assert energy == pytest.approx(7.0)
     assert minim._evaluation_manager.energy_modules is minim.energy_modules
 
 


### PR DESCRIPTION
## Summary
- delegate `_compute_energy_array_with_leaflet_tilts` and `_compute_tilt_dependent_energy_with_leaflet_tilts` through `EvaluationManager`
- preserve legacy TypeError fallback behavior for modules that read leaflet tilts from mesh state
- preserve `USES_TILT_LEAFLETS` filtering and the precomputed-area `tilt_in` / `tilt_out` fast paths
- add regression tests for the delegated leaflet energy paths

## Stack
- Base: PR530 branch `refactor/evaluation-manager-total-energy`
- This PR should merge after PR530

## Validation
- `pytest -q tests/test_refactor_compatibility.py tests/test_tilt_only_energy_skips_non_tilt_unit.py tests/test_minimizer.py tests/test_tilt_validation.py` -> 36 passed
- `pytest -q tests/test_tilt_leaflet_pure.py tests/test_curvature_kernel_optional_outputs_unit.py tests/test_fortran_kernels.py tests/test_preconditioners.py tests/test_bt_utils.py tests/test_bt_selection.py tests/test_bt_transition.py tests/test_bt_divergence.py tests/test_entities_reexports.py` -> 49 passed
- `pytest -q tests/test_bending_tilt_leaflet_energy.py tests/test_bending_tilt_leaflet_e2e.py tests/test_bending_energy.py tests/test_bending_finite_difference.py tests/test_rim_slope_match_out.py tests/test_tilt_leaflet_smoothness.py` -> 20 passed, 2 deselected