### PR TITLE
refactor: delegate leaflet gradient evaluation path

### DIFF
--- a/runtime/evaluation_manager.py
+++ b/runtime/evaluation_manager.py
@@ -602,7 +602,42 @@ class EvaluationManager:
 
         for name, module in zip(self.energy_module_names, self.energy_modules):
             scale = self.experimental_energy_scale_fn(str(name))
-            if not getattr(module, "USES_TILT_LEAFLETS", False):
+            # Fast path for the pure tilt magnitude penalties: when positions
+            # are frozen (tilt relaxation inner loop), precomputed vertex areas
+            # avoid repeated triangle cross-products.
+            if (
+                name == "tilt_in"
+                and tilt_vertex_areas_in is not None
+                and getattr(module, "USES_TILT_LEAFLETS", False)
+            ):
+                k_tilt = float(self.param_resolver.get(None, "tilt_modulus_in") or 0.0)
+                if k_tilt != 0.0:
+                    sq = np.einsum("ij,ij->i", tilts_in, tilts_in)
+                    total_energy += float(
+                        float(scale) * 0.5 * k_tilt * np.sum(sq * tilt_vertex_areas_in)
+                    )
+                    tilt_in_grad_arr += (
+                        float(scale) * k_tilt * tilts_in * tilt_vertex_areas_in[:, None]
+                    )
+                continue
+
+            if (
+                name == "tilt_out"
+                and tilt_vertex_areas_out is not None
+                and getattr(module, "USES_TILT_LEAFLETS", False)
+            ):
+                k_tilt = float(self.param_resolver.get(None, "tilt_modulus_out") or 0.0)
+                if k_tilt != 0.0:
+                    sq = np.einsum("ij,ij->i", tilts_out, tilts_out)
+                    total_energy += float(
+                        float(scale) * 0.5 * k_tilt * np.sum(sq * tilt_vertex_areas_out)
+                    )
+                    tilt_out_grad_arr += (
+                        float(scale)
+                        * k_tilt
+                        * tilts_out
+                        * tilt_vertex_areas_out[:, None]
+                    )
                 continue
 
             if hasattr(module, "compute_energy_and_gradient_array"):
@@ -617,18 +652,24 @@ class EvaluationManager:
                     gin_before = tilt_in_grad_arr.copy()
                     gout_before = tilt_out_grad_arr.copy()
 
-                E_mod = self._call_module_array(
-                    module,
-                    positions=positions,
-                    index_map=index_map,
-                    grad_arr=grad_arg,
-                    tilts_in=tilts_in,
-                    tilts_out=tilts_out,
-                    tilt_in_grad_arr=tilt_in_grad_arr,
-                    tilt_out_grad_arr=tilt_out_grad_arr,
-                    tilt_vertex_areas_in=tilt_vertex_areas_in,
-                    tilt_vertex_areas_out=tilt_vertex_areas_out,
-                )
+                try:
+                    E_mod = self._call_module_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                        grad_arr=grad_arg,
+                        tilts_in=tilts_in,
+                        tilts_out=tilts_out,
+                        tilt_in_grad_arr=tilt_in_grad_arr,
+                        tilt_out_grad_arr=tilt_out_grad_arr,
+                    )
+                except TypeError:
+                    E_mod = self._call_module_array(
+                        module,
+                        positions=positions,
+                        index_map=index_map,
+                        grad_arr=grad_arg,
+                    )
 
                 if gin_before is not None:
                     delta_in = tilt_in_grad_arr - gin_before
@@ -642,18 +683,10 @@ class EvaluationManager:
             res = module.compute_energy_and_gradient(
                 self.mesh, self.global_params, self.param_resolver
             )
+            if not isinstance(res, tuple) or len(res) < 2:
+                raise ValueError(
+                    f"Unexpected return from energy module {module}: {res!r}"
+                )
             total_energy += float(scale) * float(res[0])
-            if len(res) >= 4:
-                gin, gout = res[2], res[3]
-                if gin is not None:
-                    for vid, gvec in gin.items():
-                        row = index_map.get(int(vid))
-                        if row is not None:
-                            tilt_in_grad_arr[row] += float(scale) * gvec
-                if gout is not None:
-                    for vid, gvec in gout.items():
-                        row = index_map.get(int(vid))
-                        if row is not None:
-                            tilt_out_grad_arr[row] += float(scale) * gvec
 
         return float(total_energy)

--- a/runtime/minimizer.py
+++ b/runtime/minimizer.py
@@ -732,102 +732,18 @@ class Minimizer:
         tilt_only: bool = False,
     ) -> float:
         """Compute total energy and accumulate leaflet tilt gradients."""
-        index_map = self.mesh.vertex_index_to_row
-        if grad_dummy is None:
-            grad_dummy = np.zeros_like(positions)
-        else:
-            grad_dummy.fill(0.0)
-        tilt_in_grad_arr.fill(0.0)
-        tilt_out_grad_arr.fill(0.0)
-        total_energy = 0.0
-
-        for name, module in zip(self.energy_module_names, self.energy_modules):
-            scale = self._experimental_energy_scale_for_module(str(name))
-            # Fast path for the pure tilt magnitude penalties: when positions
-            # are frozen (tilt relaxation inner loop), precomputed vertex areas
-            # avoid repeated triangle cross-products.
-            if (
-                name == "tilt_in"
-                and tilt_vertex_areas_in is not None
-                and getattr(module, "USES_TILT_LEAFLETS", False)
-            ):
-                k_tilt = float(self.param_resolver.get(None, "tilt_modulus_in") or 0.0)
-                if k_tilt != 0.0:
-                    sq = np.einsum("ij,ij->i", tilts_in, tilts_in)
-                    total_energy += float(
-                        float(scale) * 0.5 * k_tilt * np.sum(sq * tilt_vertex_areas_in)
-                    )
-                    tilt_in_grad_arr += (
-                        float(scale) * k_tilt * tilts_in * tilt_vertex_areas_in[:, None]
-                    )
-                continue
-
-            if (
-                name == "tilt_out"
-                and tilt_vertex_areas_out is not None
-                and getattr(module, "USES_TILT_LEAFLETS", False)
-            ):
-                k_tilt = float(self.param_resolver.get(None, "tilt_modulus_out") or 0.0)
-                if k_tilt != 0.0:
-                    sq = np.einsum("ij,ij->i", tilts_out, tilts_out)
-                    total_energy += float(
-                        float(scale) * 0.5 * k_tilt * np.sum(sq * tilt_vertex_areas_out)
-                    )
-                    tilt_out_grad_arr += (
-                        float(scale)
-                        * k_tilt
-                        * tilts_out
-                        * tilt_vertex_areas_out[:, None]
-                    )
-                continue
-
-            if hasattr(module, "compute_energy_and_gradient_array"):
-                grad_arg = (
-                    None
-                    if tilt_only and getattr(module, "USES_TILT_LEAFLETS", False)
-                    else grad_dummy
-                )
-                in_before = None
-                out_before = None
-                if abs(float(scale) - 1.0) > 1.0e-15:
-                    in_before = tilt_in_grad_arr.copy()
-                    out_before = tilt_out_grad_arr.copy()
-                try:
-                    E_mod = self._call_module_array(
-                        module,
-                        positions=positions,
-                        index_map=index_map,
-                        grad_arr=grad_arg,
-                        tilts_in=tilts_in,
-                        tilts_out=tilts_out,
-                        tilt_in_grad_arr=tilt_in_grad_arr,
-                        tilt_out_grad_arr=tilt_out_grad_arr,
-                    )
-                except TypeError:
-                    E_mod = self._call_module_array(
-                        module,
-                        positions=positions,
-                        index_map=index_map,
-                        grad_arr=grad_arg,
-                    )
-                if in_before is not None and out_before is not None:
-                    in_delta = tilt_in_grad_arr - in_before
-                    out_delta = tilt_out_grad_arr - out_before
-                    tilt_in_grad_arr[:] = in_before + (float(scale) * in_delta)
-                    tilt_out_grad_arr[:] = out_before + (float(scale) * out_delta)
-                total_energy += float(scale) * float(E_mod)
-                continue
-
-            res = module.compute_energy_and_gradient(
-                self.mesh, self.global_params, self.param_resolver
-            )
-            if not isinstance(res, tuple) or len(res) < 2:
-                raise ValueError(
-                    f"Unexpected return from energy module {module}: {res!r}"
-                )
-            total_energy += float(scale) * float(res[0])
-
-        return float(total_energy)
+        self._sync_evaluation_manager()
+        return self._evaluation_manager.compute_energy_and_leaflet_tilt_gradients_array(
+            positions=positions,
+            tilts_in=tilts_in,
+            tilts_out=tilts_out,
+            tilt_in_grad_arr=tilt_in_grad_arr,
+            tilt_out_grad_arr=tilt_out_grad_arr,
+            tilt_vertex_areas_in=tilt_vertex_areas_in,
+            tilt_vertex_areas_out=tilt_vertex_areas_out,
+            grad_dummy=grad_dummy,
+            tilt_only=tilt_only,
+        )
 
     def _relax_tilts(
         self,

--- a/tests/test_refactor_compatibility.py
+++ b/tests/test_refactor_compatibility.py
@@ -175,6 +175,57 @@ class _LeafletGradientEnergyModule:
         return float(3.0 * np.sum(tilts_in) + 5.0 * np.sum(tilts_out))
 
 
+class _LeafletGradientMutatingModule:
+    USES_TILT_LEAFLETS = True
+
+    def __init__(self) -> None:
+        self.grad_args: list[np.ndarray | None] = []
+
+    def compute_energy_and_gradient_array(
+        self,
+        mesh,
+        global_params,
+        param_resolver,
+        *,
+        positions,
+        index_map,
+        grad_arr,
+        tilts_in=None,
+        tilts_out=None,
+        tilt_in_grad_arr=None,
+        tilt_out_grad_arr=None,
+    ) -> float:
+        _ = mesh, global_params, param_resolver, positions, index_map
+        self.grad_args.append(grad_arr)
+        if grad_arr is not None:
+            grad_arr += 9.0
+        if tilt_in_grad_arr is not None:
+            tilt_in_grad_arr += tilts_in
+        if tilt_out_grad_arr is not None:
+            tilt_out_grad_arr += 2.0 * tilts_out
+        return 13.0
+
+
+class _LeafletGradientRejectsTrialTiltsModule:
+    USES_TILT_LEAFLETS = True
+
+    def compute_energy_and_gradient_array(
+        self,
+        mesh,
+        global_params,
+        param_resolver,
+        *,
+        positions,
+        index_map,
+        grad_arr,
+        **kwargs,
+    ) -> float:
+        _ = mesh, global_params, param_resolver, positions, index_map, grad_arr
+        if "tilts_in" in kwargs or "tilts_out" in kwargs:
+            raise TypeError("legacy gradient module reads tilts from mesh")
+        return 17.0
+
+
 class _LeafletRejectsTrialTiltsModule:
     USES_TILT_LEAFLETS = True
 
@@ -446,6 +497,171 @@ def test_minimizer_delegates_leaflet_tilt_dependent_legacy_fallback() -> None:
 
     assert energy == pytest.approx(7.0)
     assert minim._evaluation_manager.energy_modules is minim.energy_modules
+
+
+def test_minimizer_delegates_leaflet_gradient_path_with_shape_energy() -> None:
+    mesh = _single_vertex_mesh()
+    minim = Minimizer(
+        mesh,
+        mesh.global_parameters,
+        GradientDescent(),
+        EnergyModuleManager([]),
+        ConstraintModuleManager([]),
+        quiet=True,
+    )
+    minim.energy_modules = [
+        _ShapeEnergyGradientModule(),
+        _LeafletGradientMutatingModule(),
+    ]
+    minim.energy_module_names = ["shape", "leaflet"]
+
+    tilts_in = np.asarray([[1.0, 2.0, 3.0]], dtype=float)
+    tilts_out = np.asarray([[4.0, 5.0, 6.0]], dtype=float)
+    grad_dummy = np.zeros_like(tilts_in)
+    tilt_in_grad = np.zeros_like(tilts_in)
+    tilt_out_grad = np.zeros_like(tilts_out)
+    energy = minim._compute_energy_and_leaflet_tilt_gradients_array(
+        positions=mesh.positions_view(),
+        tilts_in=tilts_in,
+        tilts_out=tilts_out,
+        tilt_in_grad_arr=tilt_in_grad,
+        tilt_out_grad_arr=tilt_out_grad,
+        grad_dummy=grad_dummy,
+    )
+
+    assert energy == pytest.approx(15.0)
+    np.testing.assert_allclose(grad_dummy, np.full_like(grad_dummy, 10.0))
+    np.testing.assert_allclose(tilt_in_grad, tilts_in)
+    np.testing.assert_allclose(tilt_out_grad, 2.0 * tilts_out)
+    assert minim._evaluation_manager.energy_modules is minim.energy_modules
+
+
+def test_minimizer_delegates_leaflet_gradient_tilt_only_keeps_shape_gradient() -> None:
+    mesh = _single_vertex_mesh()
+    leaflet = _LeafletGradientMutatingModule()
+    minim = Minimizer(
+        mesh,
+        mesh.global_parameters,
+        GradientDescent(),
+        EnergyModuleManager([]),
+        ConstraintModuleManager([]),
+        quiet=True,
+    )
+    minim.energy_modules = [_ShapeEnergyGradientModule(), leaflet]
+    minim.energy_module_names = ["shape", "leaflet"]
+
+    grad_dummy = np.zeros((1, 3), dtype=float)
+    energy = minim._compute_energy_and_leaflet_tilt_gradients_array(
+        positions=mesh.positions_view(),
+        tilts_in=np.asarray([[1.0, 2.0, 3.0]], dtype=float),
+        tilts_out=np.asarray([[4.0, 5.0, 6.0]], dtype=float),
+        tilt_in_grad_arr=np.zeros((1, 3), dtype=float),
+        tilt_out_grad_arr=np.zeros((1, 3), dtype=float),
+        grad_dummy=grad_dummy,
+        tilt_only=True,
+    )
+
+    assert energy == pytest.approx(15.0)
+    np.testing.assert_allclose(grad_dummy, np.ones_like(grad_dummy))
+    assert leaflet.grad_args == [None]
+
+
+def test_minimizer_delegates_leaflet_gradient_fast_paths() -> None:
+    mesh = _single_vertex_mesh()
+    mesh.global_parameters.set("tilt_modulus_in", 2.0)
+    mesh.global_parameters.set("tilt_modulus_out", 3.0)
+    minim = Minimizer(
+        mesh,
+        mesh.global_parameters,
+        GradientDescent(),
+        EnergyModuleManager([]),
+        ConstraintModuleManager([]),
+        quiet=True,
+    )
+    minim.energy_modules = [_LeafletMarkerModule(), _LeafletMarkerModule()]
+    minim.energy_module_names = ["tilt_in", "tilt_out"]
+
+    tilts_in = np.asarray([[1.0, 2.0, 2.0]], dtype=float)
+    tilts_out = np.asarray([[2.0, 0.0, 1.0]], dtype=float)
+    tilt_in_grad = np.zeros_like(tilts_in)
+    tilt_out_grad = np.zeros_like(tilts_out)
+    energy = minim._compute_energy_and_leaflet_tilt_gradients_array(
+        positions=mesh.positions_view(),
+        tilts_in=tilts_in,
+        tilts_out=tilts_out,
+        tilt_in_grad_arr=tilt_in_grad,
+        tilt_out_grad_arr=tilt_out_grad,
+        tilt_vertex_areas_in=np.asarray([0.5], dtype=float),
+        tilt_vertex_areas_out=np.asarray([2.0], dtype=float),
+    )
+
+    assert energy == pytest.approx(19.5)
+    np.testing.assert_allclose(tilt_in_grad, tilts_in)
+    np.testing.assert_allclose(tilt_out_grad, 6.0 * tilts_out)
+
+
+def test_minimizer_delegates_leaflet_gradient_legacy_fallback() -> None:
+    mesh = _single_vertex_mesh()
+    minim = Minimizer(
+        mesh,
+        mesh.global_parameters,
+        GradientDescent(),
+        EnergyModuleManager([]),
+        ConstraintModuleManager([]),
+        quiet=True,
+    )
+    minim.energy_modules = [_LeafletGradientRejectsTrialTiltsModule()]
+    minim.energy_module_names = ["legacy_leaflet"]
+
+    tilt_in_grad = np.ones((1, 3), dtype=float)
+    tilt_out_grad = np.ones((1, 3), dtype=float)
+    energy = minim._compute_energy_and_leaflet_tilt_gradients_array(
+        positions=mesh.positions_view(),
+        tilts_in=np.asarray([[1.0, 2.0, 3.0]], dtype=float),
+        tilts_out=np.asarray([[4.0, 5.0, 6.0]], dtype=float),
+        tilt_in_grad_arr=tilt_in_grad,
+        tilt_out_grad_arr=tilt_out_grad,
+    )
+
+    assert energy == pytest.approx(17.0)
+    np.testing.assert_allclose(tilt_in_grad, np.zeros_like(tilt_in_grad))
+    np.testing.assert_allclose(tilt_out_grad, np.zeros_like(tilt_out_grad))
+
+
+def test_minimizer_delegates_leaflet_gradient_scaled_deltas() -> None:
+    mesh = _single_vertex_mesh()
+    mesh.global_parameters.set(
+        "curved_theta_objective_ablation_mode", "inner_outer_rescaled"
+    )
+    mesh.global_parameters.set("benchmark_geometry_lane", "free_z")
+    mesh.global_parameters.set("benchmark_parameterization", "kh_physical")
+    mesh.global_parameters.set("curved_theta_objective_ablation_inner_scale", 2.0)
+    minim = Minimizer(
+        mesh,
+        mesh.global_parameters,
+        GradientDescent(),
+        EnergyModuleManager([]),
+        ConstraintModuleManager([]),
+        quiet=True,
+    )
+    minim.energy_modules = [_LeafletGradientMutatingModule()]
+    minim.energy_module_names = ["tilt_smoothness_in"]
+
+    tilts_in = np.asarray([[1.0, 2.0, 3.0]], dtype=float)
+    tilts_out = np.asarray([[4.0, 5.0, 6.0]], dtype=float)
+    tilt_in_grad = np.zeros_like(tilts_in)
+    tilt_out_grad = np.zeros_like(tilts_out)
+    energy = minim._compute_energy_and_leaflet_tilt_gradients_array(
+        positions=mesh.positions_view(),
+        tilts_in=tilts_in,
+        tilts_out=tilts_out,
+        tilt_in_grad_arr=tilt_in_grad,
+        tilt_out_grad_arr=tilt_out_grad,
+    )
+
+    assert energy == pytest.approx(26.0)
+    np.testing.assert_allclose(tilt_in_grad, 2.0 * tilts_in)
+    np.testing.assert_allclose(tilt_out_grad, 4.0 * tilts_out)
 
 
 def test_minimizer_delegates_single_tilt_gradient_path_with_sync() -> None:


### PR DESCRIPTION
## Summary
- delegate `_compute_energy_and_leaflet_tilt_gradients_array` through `EvaluationManager`
- preserve non-leaflet shape energy participation in the gradient path
- preserve `tilt_only`, legacy TypeError fallback, precomputed-area `tilt_in` / `tilt_out` fast paths, and scaled gradient delta behavior
- add regression tests covering the migrated behavior boundaries

## Stack
- Base: PR531 branch `refactor/evaluation-manager-leaflet-energy`
- This PR should merge after PR531

## Validation
- `pytest -q tests/test_refactor_compatibility.py tests/test_tilt_only_energy_skips_non_tilt_unit.py tests/test_minimizer.py tests/test_tilt_validation.py` -> 41 passed
- `pytest -q tests/test_tilt_leaflet_pure.py tests/test_curvature_kernel_optional_outputs_unit.py tests/test_fortran_kernels.py tests/test_preconditioners.py tests/test_bt_utils.py tests/test_bt_selection.py tests/test_bt_transition.py tests/test_bt_divergence.py tests/test_entities_reexports.py` -> 49 passed
- `pytest -q tests/test_bending_tilt_leaflet_energy.py tests/test_bending_tilt_leaflet_e2e.py tests/test_bending_energy.py tests/test_bending_finite_difference.py tests/test_rim_slope_match_out.py tests/test_tilt_leaflet_smoothness.py` -> 20 passed, 2 deselected