### PR TITLE
refactor: delegate shape gradient assembly

### DIFF
--- a/runtime/evaluation_manager.py
+++ b/runtime/evaluation_manager.py
@@ -131,6 +131,25 @@ class EvaluationManager:
         fn = getattr(module, "compute_energy_array")
         return self._call_fn(fn, **kwargs)
 
+    def compute_energy_and_gradient_array(
+        self, *, positions: np.ndarray
+    ) -> tuple[float, np.ndarray]:
+        """Return raw module energy and dense shape gradient for positions."""
+        index_map = self.mesh.vertex_index_to_row
+        grad_arr = np.zeros_like(positions)
+
+        total_energy = 0.0
+        for module in self.energy_modules:
+            E_mod = self._call_module_array(
+                module,
+                positions=positions,
+                index_map=index_map,
+                grad_arr=grad_arr,
+            )
+            total_energy += E_mod
+
+        return total_energy, grad_arr
+
     def compute_energy_array_total(self, *, positions: np.ndarray) -> float:
         """Compute total energy for fixed positions and current mesh tilts."""
         index_map = self.mesh.vertex_index_to_row

--- a/runtime/minimizer.py
+++ b/runtime/minimizer.py
@@ -824,19 +824,13 @@ STEP SIZE:\t {self.step_size}
 
     def compute_energy_and_gradient_array(self):
         """Return total energy and dense gradient array for the current mesh."""
-        positions, index_map, _ = self._soa_views()
-        grad_arr = np.zeros_like(positions)
-
-        total_energy = 0.0
-        for module in self.energy_modules:
-            # Use fast array path
-            E_mod = self._call_module_array(
-                module,
-                positions=positions,
-                index_map=index_map,
-                grad_arr=grad_arr,
+        positions, _, _ = self._soa_views()
+        self._sync_evaluation_manager()
+        total_energy, grad_arr = (
+            self._evaluation_manager.compute_energy_and_gradient_array(
+                positions=positions
             )
-            total_energy += E_mod
+        )
 
         # Apply constraint modifications to the shape gradient. When leaflet
         # tilts are active, joint shape+tilt constraints should project the

--- a/tests/test_kkt_projection.py
+++ b/tests/test_kkt_projection.py
@@ -673,10 +673,10 @@ def test_compute_energy_and_gradient_array_uses_joint_projection_for_stage_a() -
         np.zeros_like(mesh.positions_view()),
     )
 
-    def _call_module_array(module, **kwargs):
-        _ = module
-        kwargs["grad_arr"][:] = np.asarray([[1.0, 2.0, 0.0], [0.0, -1.0, 1.0]])
-        return 3.25
+    class RawEvaluationManager:
+        def compute_energy_and_gradient_array(self, *, positions):
+            _ = positions
+            return 3.25, np.asarray([[1.0, 2.0, 0.0], [0.0, -1.0, 1.0]])
 
     def _tilt_gradients(**kwargs):
         kwargs["tilt_in_grad_arr"][:] = np.asarray([[0.25, 0.0, 0.0], [0.0, 0.5, 0.0]])
@@ -685,7 +685,8 @@ def test_compute_energy_and_gradient_array_uses_joint_projection_for_stage_a() -
         )
         return 0.0
 
-    minim._call_module_array = _call_module_array
+    minim._sync_evaluation_manager = lambda: None
+    minim._evaluation_manager = RawEvaluationManager()
     minim._compute_energy_and_leaflet_tilts_array = lambda *args, **kwargs: None
     minim._compute_energy_and_leaflet_tilt_gradients_array = _tilt_gradients
     minim.constraint_manager = cm
@@ -729,12 +730,13 @@ def test_compute_energy_and_gradient_array_uses_legacy_projection_outside_stage_
         np.zeros_like(mesh.positions_view()),
     )
 
-    def _call_module_array(module, **kwargs):
-        _ = module
-        kwargs["grad_arr"][:] = np.asarray([[1.0, 2.0, 0.0], [0.0, -1.0, 1.0]])
-        return 3.25
+    class RawEvaluationManager:
+        def compute_energy_and_gradient_array(self, *, positions):
+            _ = positions
+            return 3.25, np.asarray([[1.0, 2.0, 0.0], [0.0, -1.0, 1.0]])
 
-    minim._call_module_array = _call_module_array
+    minim._sync_evaluation_manager = lambda: None
+    minim._evaluation_manager = RawEvaluationManager()
     minim.constraint_manager = cm
 
     energy, grad_arr = Minimizer.compute_energy_and_gradient_array(minim)

--- a/tests/test_refactor_compatibility.py
+++ b/tests/test_refactor_compatibility.py
@@ -383,6 +383,27 @@ def test_minimizer_delegates_total_energy_path_with_sync() -> None:
     assert minim._evaluation_manager.energy_module_names is minim.energy_module_names
 
 
+def test_minimizer_delegates_shape_gradient_assembly_with_sync() -> None:
+    mesh = _single_vertex_mesh()
+    minim = Minimizer(
+        mesh,
+        mesh.global_parameters,
+        GradientDescent(),
+        EnergyModuleManager([]),
+        ConstraintModuleManager([]),
+        quiet=True,
+    )
+    minim.energy_modules = [_ShapeEnergyGradientModule()]
+    minim.energy_module_names = ["shape"]
+
+    energy, grad_arr = minim.compute_energy_and_gradient_array()
+
+    assert energy == pytest.approx(2.0)
+    np.testing.assert_allclose(grad_arr, np.ones_like(mesh.positions_view()))
+    assert minim._evaluation_manager.energy_modules is minim.energy_modules
+    assert minim._evaluation_manager.energy_module_names is minim.energy_module_names
+
+
 def test_minimizer_delegates_total_energy_with_projected_tilts_path() -> None:
     mesh = _single_vertex_mesh()
     minim = Minimizer(


### PR DESCRIPTION
## Summary
- move raw shape energy/gradient array assembly into `EvaluationManager`
- keep constraint projection, fixed-vertex zeroing, and joint tilt projection logic in `Minimizer`
- update KKT projection tests to isolate projection behavior through a fake evaluation manager
- add a regression test for shape-gradient delegation and bridge syncing

## Stack
- Base: PR532 branch `refactor/evaluation-manager-leaflet-gradients`
- This PR should merge after PR532

## Validation
- `pytest -q tests/test_refactor_compatibility.py tests/test_kkt_projection.py tests/test_tilt_only_energy_skips_non_tilt_unit.py tests/test_minimizer.py tests/test_tilt_validation.py` -> 57 passed
- `pytest -q tests/test_tilt_leaflet_pure.py tests/test_curvature_kernel_optional_outputs_unit.py tests/test_fortran_kernels.py tests/test_preconditioners.py tests/test_bt_utils.py tests/test_bt_selection.py tests/test_bt_transition.py tests/test_bt_divergence.py tests/test_entities_reexports.py` -> 49 passed
- `pytest -q tests/test_bending_tilt_leaflet_energy.py tests/test_bending_tilt_leaflet_e2e.py tests/test_bending_energy.py tests/test_bending_finite_difference.py tests/test_rim_slope_match_out.py tests/test_tilt_leaflet_smoothness.py` -> 20 passed, 2 deselected