### PR TITLE
refactor: move energy breakdown evaluation manager path

### DIFF
--- a/runtime/evaluation_manager.py
+++ b/runtime/evaluation_manager.py
@@ -150,6 +150,37 @@ class EvaluationManager:
 
         return total_energy, grad_arr
 
+    def compute_energy_breakdown(self, *, positions: np.ndarray) -> dict[str, float]:
+        """Return per-module energy contributions for fixed positions."""
+        index_map = self.mesh.vertex_index_to_row
+        grad_dummy = self.energy_context_fn().scratch_array(
+            "energy_breakdown_grad_dummy",
+            shape=positions.shape,
+            dtype=positions.dtype,
+        )
+        breakdown: dict[str, float] = {}
+
+        for name, module in zip(self.energy_module_names, self.energy_modules):
+            scale = self.experimental_energy_scale_fn(str(name))
+            if hasattr(module, "compute_energy_and_gradient_array"):
+                grad_dummy.fill(0.0)
+                E_mod = self._call_module_array(
+                    module,
+                    positions=positions,
+                    index_map=index_map,
+                    grad_arr=grad_dummy,
+                )
+            else:
+                E_mod, _ = module.compute_energy_and_gradient(
+                    self.mesh,
+                    self.global_params,
+                    self.param_resolver,
+                    compute_gradient=False,
+                )
+            breakdown[name] = float(scale) * float(E_mod)
+
+        return breakdown
+
     def compute_energy_array_total(self, *, positions: np.ndarray) -> float:
         """Compute total energy for fixed positions and current mesh tilts."""
         index_map = self.mesh.vertex_index_to_row

--- a/runtime/minimizer.py
+++ b/runtime/minimizer.py
@@ -112,10 +112,6 @@ class Minimizer:
         self._soa_grad_dummy: np.ndarray | None = None
         self._last_mesh_op_tilt_constraints_enforced: bool = False
         self._energy_context: EnergyContext | None = None
-        self._module_accepts_ctx: dict[int, bool] = {}
-        self._module_energy_array_spec: dict[
-            int, tuple[bool, bool, frozenset[str] | None]
-        ] = {}
         self._stepper_accepts_trial_energy_fn: bool | None = None
         self._last_tilt_projection_stats: dict[str, float | int | str] = {
             "projection_cadence": "per_step",
@@ -175,8 +171,6 @@ class Minimizer:
         self._tilt_fixed_mask_out_version = -1
         self._tilt_fixed_mask_out_vertex_version = -1
         self._energy_context = None
-        self._module_energy_array_spec = {}
-        self._module_accepts_ctx = {}
         self._stepper_accepts_trial_energy_fn = None
 
     def _sync_evaluation_manager(self) -> None:
@@ -222,98 +216,6 @@ class Minimizer:
                     accepts = False
             self._stepper_accepts_trial_energy_fn = accepts
         return bool(self._stepper_accepts_trial_energy_fn)
-
-    def _call_module_array(self, module, **kwargs):
-        """Call module array API with explicit ctx and graceful fallback."""
-        key = id(module)
-        accepts_ctx = self._module_accepts_ctx.get(key)
-        if accepts_ctx is None:
-            accepts_ctx = False
-            fn = getattr(module, "compute_energy_and_gradient_array", None)
-            if fn is not None:
-                try:
-                    sig = inspect.signature(fn)
-                    if "ctx" in sig.parameters:
-                        accepts_ctx = True
-                    else:
-                        accepts_ctx = any(
-                            p.kind is inspect.Parameter.VAR_KEYWORD
-                            for p in sig.parameters.values()
-                        )
-                except (TypeError, ValueError):
-                    accepts_ctx = False
-            self._module_accepts_ctx[key] = accepts_ctx
-
-        if accepts_ctx:
-            return module.compute_energy_and_gradient_array(
-                self.mesh,
-                self.global_params,
-                self.param_resolver,
-                ctx=self.energy_context(),
-                **kwargs,
-            )
-        return module.compute_energy_and_gradient_array(
-            self.mesh,
-            self.global_params,
-            self.param_resolver,
-            **kwargs,
-        )
-
-    def _call_module_energy_array(self, module, **kwargs):
-        """Call energy-only array API while honoring per-module signatures."""
-        fn = getattr(module, "compute_energy_array")
-        key = id(module)
-        spec = self._module_energy_array_spec.get(key)
-        if spec is None:
-            accepts_resolver = False
-            accepts_ctx = False
-            accepted_kwargs: frozenset[str] | None = frozenset()
-            try:
-                sig = inspect.signature(fn)
-                params = sig.parameters
-                accepts_resolver = "param_resolver" in params
-                accepts_var_kwargs = any(
-                    p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()
-                )
-                accepts_ctx = "ctx" in params or accepts_var_kwargs
-                if accepts_var_kwargs:
-                    accepted_kwargs = None
-                else:
-                    accepted_kwargs = frozenset(
-                        name
-                        for name, param in params.items()
-                        if param.kind
-                        in (
-                            inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                            inspect.Parameter.KEYWORD_ONLY,
-                        )
-                    )
-            except (TypeError, ValueError):
-                accepted_kwargs = None
-            spec = (accepts_resolver, accepts_ctx, accepted_kwargs)
-            self._module_energy_array_spec[key] = spec
-
-        accepts_resolver, accepts_ctx, accepted_kwargs = spec
-        call_kwargs = kwargs
-        if accepted_kwargs is not None:
-            call_kwargs = {
-                name: value for name, value in kwargs.items() if name in accepted_kwargs
-            }
-        if accepts_ctx:
-            call_kwargs = dict(call_kwargs)
-            call_kwargs["ctx"] = self.energy_context()
-
-        if accepts_resolver:
-            return fn(self.mesh, self.global_params, self.param_resolver, **call_kwargs)
-        return fn(self.mesh, self.global_params, **call_kwargs)
-
-    @staticmethod
-    def _coerce_energy_value(energy_value) -> float:
-        """Normalize scalar- or array-valued module energies to a float total."""
-        energy_arr = np.asarray(energy_value, dtype=float)
-        if energy_arr.ndim == 0:
-            return float(energy_arr)
-        return float(np.sum(energy_arr))
 
     def _soa_views(self) -> tuple[np.ndarray, Dict[int, int], np.ndarray]:
         """Return cached SoA views for positions, index map, and a scratch buffer."""
@@ -944,28 +846,9 @@ STEP SIZE:\t {self.step_size}
         # minimization iterations into report-only code paths.
         self.mesh._curvature_cache = {}
         self.mesh._curvature_version = -1
-        positions, index_map, grad_dummy = self._soa_views()
-        breakdown: Dict[str, float] = {}
-
-        for name, module in zip(self.energy_module_names, self.energy_modules):
-            scale = self._experimental_energy_scale_for_module(str(name))
-            if hasattr(module, "compute_energy_and_gradient_array"):
-                grad_dummy.fill(0.0)
-                E_mod = self._call_module_array(
-                    module,
-                    positions=positions,
-                    index_map=index_map,
-                    grad_arr=grad_dummy,
-                )
-            else:
-                E_mod, _ = module.compute_energy_and_gradient(
-                    self.mesh,
-                    self.global_params,
-                    self.param_resolver,
-                    compute_gradient=False,
-                )
-            breakdown[name] = float(scale) * float(E_mod)
-        return breakdown
+        positions, _, _ = self._soa_views()
+        self._sync_evaluation_manager()
+        return self._evaluation_manager.compute_energy_breakdown(positions=positions)
 
     def _grad_arr_to_dict(self, grad_arr: np.ndarray) -> Dict[int, np.ndarray]:
         """Convert a dense gradient array into a sparse dict keyed by vertex id."""

--- a/tests/test_refactor_compatibility.py
+++ b/tests/test_refactor_compatibility.py
@@ -97,6 +97,14 @@ class _NonTiltEnergyModule:
         return 100.0
 
 
+class _LegacyEnergyModule:
+    def compute_energy_and_gradient(
+        self, mesh, global_params, param_resolver, *, compute_gradient=True
+    ):
+        _ = mesh, global_params, param_resolver, compute_gradient
+        return 5.0, {}
+
+
 class _NonTiltEnergyArrayRejectsTiltsModule:
     def compute_energy_array(
         self,
@@ -400,6 +408,30 @@ def test_minimizer_delegates_shape_gradient_assembly_with_sync() -> None:
 
     assert energy == pytest.approx(2.0)
     np.testing.assert_allclose(grad_arr, np.ones_like(mesh.positions_view()))
+    assert minim._evaluation_manager.energy_modules is minim.energy_modules
+    assert minim._evaluation_manager.energy_module_names is minim.energy_module_names
+
+
+def test_minimizer_delegates_energy_breakdown_with_sync() -> None:
+    mesh = _single_vertex_mesh()
+    minim = Minimizer(
+        mesh,
+        mesh.global_parameters,
+        GradientDescent(),
+        EnergyModuleManager([]),
+        ConstraintModuleManager([]),
+        quiet=True,
+    )
+    minim.energy_modules = [_ShapeEnergyGradientModule(), _LegacyEnergyModule()]
+    minim.energy_module_names = ["shape", "legacy"]
+    mesh._curvature_cache = {"stale": object()}
+    mesh._curvature_version = 99
+
+    breakdown = minim.compute_energy_breakdown()
+
+    assert breakdown == pytest.approx({"shape": 2.0, "legacy": 5.0})
+    assert mesh._curvature_cache == {}
+    assert mesh._curvature_version == -1
     assert minim._evaluation_manager.energy_modules is minim.energy_modules
     assert minim._evaluation_manager.energy_module_names is minim.energy_module_names
 


### PR DESCRIPTION
## Summary
- move diagnostic energy breakdown assembly into `EvaluationManager`
- keep diagnostic curvature-cache clearing in `Minimizer`
- remove now-unused minimizer module-call helper caches and helper methods
- add regression coverage for breakdown delegation and curvature-cache reset behavior

## Stack
- Base: PR533 branch `refactor/evaluation-manager-shape-gradient`
- This PR should merge after PR533

## Validation
- `pytest -q tests/test_refactor_compatibility.py tests/test_kkt_projection.py tests/test_tilt_only_energy_skips_non_tilt_unit.py tests/test_minimizer.py tests/test_tilt_validation.py` -> 58 passed
- `pytest -q tests/test_tilt_leaflet_pure.py tests/test_curvature_kernel_optional_outputs_unit.py tests/test_fortran_kernels.py tests/test_preconditioners.py tests/test_bt_utils.py tests/test_bt_selection.py tests/test_bt_transition.py tests/test_bt_divergence.py tests/test_entities_reexports.py` -> 49 passed
- `pytest -q tests/test_bending_tilt_leaflet_energy.py tests/test_bending_tilt_leaflet_e2e.py tests/test_bending_energy.py tests/test_bending_finite_difference.py tests/test_rim_slope_match_out.py tests/test_tilt_leaflet_smoothness.py` -> 20 passed, 2 deselected