### PR TITLE
Extract save_geometry to io_writers.py

### DIFF
--- a/geometry/geom_io.py
+++ b/geometry/geom_io.py
@@ -11,7 +11,7 @@ from core.parameters.global_parameters import GlobalParameters
 from geometry.entities import Body, Edge, Facet, Mesh, Vertex
 from runtime.refinement import refine_polygonal_facets
 
-from .io_writers import save_geometry
+from .io_writers import save_geometry as save_geometry
 
 logger = logging.getLogger("membrane_solver")
 


### PR DESCRIPTION
Incrementally splits geom_io.py by moving save/export logic into a dedicated io_writers module, while preserving the public API in geom_io.py.